### PR TITLE
fix: add recompute_graph_embeddings to slow_path_queue task_type constraint (#61)

### DIFF
--- a/sql/016_fix_task_type_constraint.sql
+++ b/sql/016_fix_task_type_constraint.sql
@@ -1,0 +1,14 @@
+-- covalence#61: Add 'recompute_graph_embeddings' to slow_path_queue task_type constraint.
+-- The admin maintenance endpoint queues this task type, but the CHECK constraint
+-- previously did not include it, causing HTTP 500 on POST /admin/maintenance.
+
+ALTER TABLE covalence.slow_path_queue
+  DROP CONSTRAINT slow_path_queue_task_type_check;
+
+ALTER TABLE covalence.slow_path_queue
+  ADD CONSTRAINT slow_path_queue_task_type_check
+  CHECK (task_type = ANY (ARRAY[
+    'compile', 'infer_edges', 'resolve_contention', 'split', 'merge',
+    'embed', 'contention_check', 'tree_index', 'tree_embed',
+    'recompute_graph_embeddings'
+  ]));


### PR DESCRIPTION
## Summary

Fixes covalence#61. Adds a migration that updates the `slow_path_queue.task_type` CHECK constraint to include `recompute_graph_embeddings`.

## Root cause

`admin_service.rs` queues `recompute_graph_embeddings` tasks but the DB constraint only allowed the original 9 task types. Every `POST /admin/maintenance` with `recompute_graph_embeddings: true` failed silently with HTTP 500.

## Impact of this fix

- Graph embeddings are now computable: 449 spectral + 367 node2vec vectors populated on first successful run
- Divergence detector now works: 266 nodes scanned, 230 fragmented nodes identified
- Structural search now has real data

## Migration

`sql/016_fix_task_type_constraint.sql` — drops and recreates the CHECK constraint with `recompute_graph_embeddings` added. Applied to production and test DBs.

## Testing

- `POST /admin/maintenance {recompute_graph_embeddings: true}` → HTTP 200, returns `queued recompute_graph_embeddings(method=node2vec)`
- All existing tests pass