### PR TITLE
fix: replace non-existent updated_at column in process_queue cleanup (closes #139)

### DIFF
--- a/engine/src/services/admin_service.rs
+++ b/engine/src/services/admin_service.rs
@@ -283,7 +283,7 @@ impl AdminService {
                    WHERE task_type = 'embed'
                      AND status = 'failed'
                      AND node_id IS NOT NULL
-                     AND updated_at < now() - interval '1 hour'
+                     AND COALESCE(completed_at, started_at, created_at) < now() - interval '1 hour'
                      AND EXISTS (
                        SELECT 1 FROM covalence.node_embeddings ne
                        WHERE ne.node_id = slow_path_queue.node_id
@@ -303,7 +303,7 @@ impl AdminService {
                 r#"DELETE FROM covalence.slow_path_queue
                    WHERE status = 'failed'
                      AND node_id IS NULL
-                     AND updated_at < now() - interval '24 hours'"#,
+                     AND COALESCE(completed_at, started_at, created_at) < now() - interval '24 hours'"#,
             )
             .execute(&self.pool)
             .await?;


### PR DESCRIPTION
## Problem
`admin_maintenance(process_queue: true)` fails with "internal database error" because the queue cleanup code (added in #133) references an `updated_at` column that does not exist on `covalence.slow_path_queue`.

Confirmed via psql: `ERROR: column "updated_at" does not exist`

This has blocked queue draining since the 8:31 AM binary deploy — 126 pending items stuck.

## Fix
Replace `updated_at` with `COALESCE(completed_at, started_at, created_at)` in both Pass A and Pass B of the `process_queue` cleanup block.

## Test
`cargo check` clean. SQL verified against actual table schema in psql.