### PR TITLE
fix: cap slow-path worker concurrency at 6 concurrent LLM tasks (closes #141)

### DIFF
--- a/engine/src/worker/consolidation.rs
+++ b/engine/src/worker/consolidation.rs
@@ -572,7 +572,7 @@ SOURCE DOCUMENTS:\n\
         // blocking on slow or hung API endpoints.
         let t0 = Instant::now();
         let llm_result = tokio::time::timeout(
-            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(120),
             llm.complete(&prompt, 4096),
         )
         .await

--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -143,7 +143,7 @@ pub async fn run_with_token(pool: PgPool, llm: Arc<dyn LlmClient>, token: Cancel
         if join_set.len() >= MAX_CONCURRENT_LLM_TASKS {
             tracing::debug!(
                 in_flight = join_set.len(),
-                cap       = MAX_CONCURRENT_LLM_TASKS,
+                cap = MAX_CONCURRENT_LLM_TASKS,
                 "worker: concurrency cap reached — skipping claim this cycle"
             );
         } else {

--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -47,6 +47,13 @@ const MAX_ATTEMPTS: i64 = 3;
 /// How long we wait between poll cycles.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
 
+/// Maximum number of concurrently in-flight LLM tasks.
+///
+/// Capping the JoinSet prevents 50-100+ simultaneous gpt-4.1-mini calls that
+/// cascade into OpenAI rate-limit errors and cause every task to exhaust its
+/// 3 retry attempts (covalence#141).
+const MAX_CONCURRENT_LLM_TASKS: usize = 6;
+
 /// Number of poll cycles between consolidation heartbeat scans (~60 s).
 const CONSOLIDATION_HEARTBEAT_INTERVAL: u64 = 30;
 
@@ -131,22 +138,31 @@ pub async fn run_with_token(pool: PgPool, llm: Arc<dyn LlmClient>, token: Cancel
             }
         }
 
-        // Claim one pending task and spawn its execution into the JoinSet.
-        match claim_task(&pool).await {
-            Ok(Some(task)) => {
-                tracing::debug!(
-                    task_id   = %task.id,
-                    task_type = %task.task_type,
-                    "worker: claimed task, spawning"
-                );
-                let pool_c = pool.clone();
-                let llm_c = Arc::clone(&llm);
-                join_set.spawn(async move {
-                    execute_and_finalize(pool_c, llm_c, task).await;
-                });
+        // Claim one pending task and spawn its execution into the JoinSet,
+        // but only when we are below the concurrency cap (covalence#141).
+        if join_set.len() >= MAX_CONCURRENT_LLM_TASKS {
+            tracing::debug!(
+                in_flight = join_set.len(),
+                cap       = MAX_CONCURRENT_LLM_TASKS,
+                "worker: concurrency cap reached — skipping claim this cycle"
+            );
+        } else {
+            match claim_task(&pool).await {
+                Ok(Some(task)) => {
+                    tracing::debug!(
+                        task_id   = %task.id,
+                        task_type = %task.task_type,
+                        "worker: claimed task, spawning"
+                    );
+                    let pool_c = pool.clone();
+                    let llm_c = Arc::clone(&llm);
+                    join_set.spawn(async move {
+                        execute_and_finalize(pool_c, llm_c, task).await;
+                    });
+                }
+                Ok(None) => {} // no work available right now
+                Err(e) => tracing::error!("worker poll error: {e:#}"),
             }
-            Ok(None) => {} // no work available right now
-            Err(e) => tracing::error!("worker poll error: {e:#}"),
         }
 
         // Sleep until the next poll cycle, or exit immediately on cancellation.

--- a/engine/src/worker/reconsolidation.rs
+++ b/engine/src/worker/reconsolidation.rs
@@ -287,7 +287,7 @@ SOURCE DOCUMENTS:\n\
     // blocking on slow or hung API endpoints.
     let t0 = Instant::now();
     let llm_result = tokio::time::timeout(
-        std::time::Duration::from_secs(60),
+        std::time::Duration::from_secs(120),
         llm.complete(&prompt, 4096),
     )
     .await


### PR DESCRIPTION
## Problem

The slow-path worker had no concurrency limit on its `JoinSet`. With 120+ pending tasks, 50-100+ simultaneous `gpt-4.1-mini` calls were spawned each poll cycle, triggering OpenAI rate-limit cascades. Every LLM call then hit the 60-second `tokio::time::timeout` and tasks failed permanently after 3 attempts.

## Changes

### `engine/src/worker/mod.rs`
- Added constant `MAX_CONCURRENT_LLM_TASKS: usize = 6`
- Wrapped the `claim_task()` call in an `else` branch: new tasks are only claimed when `join_set.len() < MAX_CONCURRENT_LLM_TASKS`. In-flight tasks are completely unaffected — the cap only blocks *new* claims, preserving the existing drain logic on shutdown.

### `engine/src/worker/consolidation.rs`
- LLM `tokio::time::timeout`: `60s` → `120s`

### `engine/src/worker/reconsolidation.rs`
- LLM `tokio::time::timeout`: `60s` → `120s`

(`critique.rs` has no timeout wrapper — nothing to change there.)

## Verification

```
cd engine && cargo check
# Finished `dev` profile — 0 errors, 17 pre-existing warnings
```

Closes #141