### PR TITLE
fix(admin): correct completed_24h status filter 'completed' → 'complete' (closes #153)

### DIFF
--- a/engine/src/services/admin_service.rs
+++ b/engine/src/services/admin_service.rs
@@ -169,7 +169,7 @@ impl AdminService {
                COUNT(*) FILTER (WHERE status = 'pending') AS pending, \
                COUNT(*) FILTER (WHERE status = 'processing') AS processing, \
                COUNT(*) FILTER (WHERE status = 'failed') AS failed, \
-               COUNT(*) FILTER (WHERE status = 'completed' AND completed_at > now() - interval '24 hours') AS completed_24h \
+               COUNT(*) FILTER (WHERE status = 'complete' AND completed_at > now() - interval '24 hours') AS completed_24h \
              FROM covalence.slow_path_queue"
         ).fetch_one(&self.pool).await?;
 


### PR DESCRIPTION
## Problem
`admin_stats` always returned `completed_24h: 0` because the SQL filter checked for `status = 'completed'` but the actual enum value stored in `covalence.slow_path_queue` is `'complete'` (no trailing **d**).

## Fix
One-character change in `engine/src/services/admin_service.rs` line 172:
```sql
-- before
COUNT(*) FILTER (WHERE status = 'completed' AND ...)
-- after
COUNT(*) FILTER (WHERE status = 'complete'  AND ...)
```

## Verification
- `cargo check` → clean (21 pre-existing warnings, 0 errors)
- `cargo fmt` → no changes
- No schema changes, no behavioural changes beyond the stat now returning the correct count.

Closes #153