### PR TITLE
docs(workers): update stale 60s→120s timeout comments (closes #148)

### DIFF
--- a/engine/src/worker/consolidation.rs
+++ b/engine/src/worker/consolidation.rs
@@ -568,7 +568,7 @@ SOURCE DOCUMENTS:\n\
         );
 
         // ── 8. LLM completion (with timeout — Fix #84) ──────────────────────
-        // Wrap the LLM call in a 60-second timeout to prevent indefinite
+        // Wrap the LLM call in a 120-second timeout to prevent indefinite
         // blocking on slow or hung API endpoints.
         let t0 = Instant::now();
         let llm_result = tokio::time::timeout(
@@ -580,9 +580,9 @@ SOURCE DOCUMENTS:\n\
             tracing::warn!(
                 task_id    = %task.id,
                 article_id = %article_id,
-                "consolidate_article: LLM completion timed out after 60s"
+                "consolidate_article: LLM completion timed out after 120s"
             );
-            Err(anyhow::anyhow!("LLM completion timed out after 60s"))
+            Err(anyhow::anyhow!("LLM completion timed out after 120s"))
         });
         let _llm_latency_ms = t0.elapsed().as_millis() as i32;
 

--- a/engine/src/worker/reconsolidation.rs
+++ b/engine/src/worker/reconsolidation.rs
@@ -283,7 +283,7 @@ SOURCE DOCUMENTS:\n\
     );
 
     // ── 6. LLM completion (with timeout — Fix #84) ──────────────────────────
-    // Wrap the LLM call in a 60-second timeout to prevent indefinite
+    // Wrap the LLM call in a 120-second timeout to prevent indefinite
     // blocking on slow or hung API endpoints.
     let t0 = Instant::now();
     let llm_result = tokio::time::timeout(
@@ -295,9 +295,9 @@ SOURCE DOCUMENTS:\n\
         tracing::warn!(
             task_id    = %task.id,
             article_id = %article_id,
-            "reconsolidate: LLM completion timed out after 60s"
+            "reconsolidate: LLM completion timed out after 120s"
         );
-        Err(anyhow::anyhow!("LLM completion timed out after 60s"))
+        Err(anyhow::anyhow!("LLM completion timed out after 120s"))
     });
     let _llm_latency_ms = t0.elapsed().as_millis() as i32;
 


### PR DESCRIPTION
## Summary

Fixes stale inline comments and error message strings flagged by the CoPilot audit (covalence#148).

PR #142 bumped the LLM-completion timeout from 60 s → 120 s in the actual `tokio::time::timeout` calls, but the surrounding comment prose and the `.warn`/`anyhow!` error strings were not updated and still referenced 60 s.

## Files changed

| File | Lines updated |
|---|---|
| `engine/src/worker/consolidation.rs` | 571 (comment), 583 (warn string), 585 (error string) |
| `engine/src/worker/reconsolidation.rs` | 286 (comment), 298 (warn string), 300 (error string) |

## Verification

- `cargo check` → clean (zero new warnings; 21 pre-existing warnings unchanged)
- `cargo fmt -- --check` → no diff

## No logic changes

This is a documentation-only fix. No runtime behaviour is altered.