### PR TITLE
feat(plugin): add bearer token auth to inference proxy endpoints (closes #152)

### DIFF
--- a/plugin/config.ts
+++ b/plugin/config.ts
@@ -15,6 +15,7 @@ export type CovalenceConfig = {
   autoCompileOnFlush: boolean;
   includeSystemMessages: boolean;
   inferenceEnabled: boolean;
+  inferenceToken?: string;
   inferenceModel?: string;
   embeddingModel: string;
   chatModel: string;
@@ -26,10 +27,12 @@ export const covalenceConfigSchema = {
 
     const serverUrl = resolveEnvVar(String(raw.serverUrl ?? "http://localhost:8430"));
     const authToken = raw.authToken ? resolveEnvVar(String(raw.authToken)) : undefined;
+    const inferenceToken = raw.inferenceToken ? resolveEnvVar(String(raw.inferenceToken)) : undefined;
 
     return {
       serverUrl: serverUrl.replace(/\/+$/, ""),
       authToken,
+      inferenceToken,
       autoRecall: raw.autoRecall !== false,
       autoCapture: raw.autoCapture === true,
       recallMaxResults: typeof raw.recallMaxResults === "number" ? raw.recallMaxResults : 5,

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -1121,6 +1121,7 @@ const covalencePlugin = {
 
     if (cfg.inferenceEnabled) {
       registerInferenceEndpoints(api, {
+        inferenceToken: cfg.inferenceToken,
         inferenceModel: cfg.inferenceModel,
         chatModel: cfg.chatModel,
         embeddingModel: cfg.embeddingModel,

--- a/plugin/inference.ts
+++ b/plugin/inference.ts
@@ -10,6 +10,7 @@
  * configured model providers.
  */
 
+import * as crypto from "crypto";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { IncomingMessage, ServerResponse } from "http";
 
@@ -60,7 +61,9 @@ export function registerInferenceEndpoints(
       // Validate bearer token if configured
       if (config.inferenceToken) {
         const authHeader = (req.headers["authorization"] as string | undefined) ?? "";
-        if (authHeader !== `Bearer ${config.inferenceToken}`) {
+        const expected = Buffer.from(`Bearer ${config.inferenceToken}`);
+        const actual = Buffer.from(authHeader);
+        if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
           res.writeHead(401, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;
@@ -145,7 +148,9 @@ export function registerInferenceEndpoints(
       // Validate bearer token if configured
       if (config.inferenceToken) {
         const authHeader = (req.headers["authorization"] as string | undefined) ?? "";
-        if (authHeader !== `Bearer ${config.inferenceToken}`) {
+        const expected = Buffer.from(`Bearer ${config.inferenceToken}`);
+        const actual = Buffer.from(authHeader);
+        if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
           res.writeHead(401, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Unauthorized" }));
           return;

--- a/plugin/inference.ts
+++ b/plugin/inference.ts
@@ -42,6 +42,7 @@ interface EmbeddingRequest {
 export function registerInferenceEndpoints(
   api: OpenClawPluginApi,
   config: {
+    inferenceToken?: string;
     inferenceModel?: string;
     chatModel: string;
     embeddingModel: string;
@@ -54,7 +55,18 @@ export function registerInferenceEndpoints(
   // -------------------------------------------------------------------------
   api.registerHttpRoute({
     path: "/covalence/v1/chat/completions",
+    auth: "plugin",
     handler: async (req: IncomingMessage, res: ServerResponse) => {
+      // Validate bearer token if configured
+      if (config.inferenceToken) {
+        const authHeader = (req.headers["authorization"] as string | undefined) ?? "";
+        if (authHeader !== `Bearer ${config.inferenceToken}`) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Unauthorized" }));
+          return;
+        }
+      }
+
       if (req.method !== "POST") {
         res.writeHead(405, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Method not allowed" }));
@@ -128,7 +140,18 @@ export function registerInferenceEndpoints(
   // -------------------------------------------------------------------------
   api.registerHttpRoute({
     path: "/covalence/v1/embeddings",
+    auth: "plugin",
     handler: async (req: IncomingMessage, res: ServerResponse) => {
+      // Validate bearer token if configured
+      if (config.inferenceToken) {
+        const authHeader = (req.headers["authorization"] as string | undefined) ?? "";
+        if (authHeader !== `Bearer ${config.inferenceToken}`) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Unauthorized" }));
+          return;
+        }
+      }
+
       if (req.method !== "POST") {
         res.writeHead(405, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Method not allowed" }));

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -59,6 +59,12 @@
       "label": "Inference Proxy",
       "help": "Expose OpenAI-compatible /covalence/v1/chat/completions and /embeddings endpoints for Covalence engine"
     },
+    "inferenceToken": {
+      "label": "Inference Token",
+      "sensitive": true,
+      "placeholder": "or use ${COVALENCE_INFERENCE_TOKEN}",
+      "help": "Bearer token required to call the inference proxy endpoints (leave empty to disable auth)"
+    },
     "inferenceModel": {
       "label": "Inference Model",
       "placeholder": "github-copilot/gpt-4.1-mini",
@@ -118,6 +124,9 @@
       "inferenceEnabled": {
         "type": "boolean",
         "default": true
+      },
+      "inferenceToken": {
+        "type": "string"
       },
       "inferenceModel": {
         "type": "string"


### PR DESCRIPTION
## Summary

Adds two-layer authentication to the Covalence inference proxy endpoints:

1. **Route level** — `auth: "plugin"` on both `registerHttpRoute()` calls, replacing `auth: "none"`. OpenClaw validates the gateway token before the handler is reached.
2. **Handler level** — explicit `Authorization: Bearer <inferenceToken>` check at the top of each handler. Returns HTTP 401 if the header is missing or doesn't match. Validation is skipped gracefully when `inferenceToken` is not configured (backward-compatible).

## Files Changed

### `plugin/config.ts`
- Added `inferenceToken?: string` to `CovalenceConfig` type
- Added parsing + env-var resolution for `inferenceToken` (same pattern as `authToken`)

### `plugin/inference.ts`
- `auth: "none"` → `auth: "plugin"` on both route registrations
- Added bearer token guard at the top of each handler function

### `plugin/index.ts`
- Threads `inferenceToken: cfg.inferenceToken` into the `registerInferenceEndpoints` call

### `plugin/openclaw.plugin.json`
- Added `inferenceToken` to `uiHints` (labelled, sensitive, with env-var placeholder)
- Added `inferenceToken` to `configSchema.properties`

## Verification

`npx tsc --noEmit` from `plugin/` exits cleanly (no output).

## Deployment Notes

Chris: set `inferenceToken` in the plugin config to `${COVALENCE_INFERENCE_TOKEN}` and export the env var in the engine plist, then set the same token as the `OPENAI_API_KEY` / bearer header in the engine's HTTP client config.