### PR TITLE
fix: tighten edge_causal_metadata bootstrap predicate (closes #146)

### DIFF
--- a/engine/migrations/036_fix_edge_causal_metadata_bootstrap.sql
+++ b/engine/migrations/036_fix_edge_causal_metadata_bootstrap.sql
@@ -1,0 +1,75 @@
+-- Migration 036: Fix overly-broad bootstrap predicate in edge_causal_metadata (covalence#146)
+--
+-- Problem
+-- -------
+-- Migration 034 seeded edge_causal_metadata with a WHERE clause that contained:
+--
+--     WHERE LOWER(e.edge_type) IN ('originates', 'compiled_from', ...)
+--        OR COALESCE(e.causal_weight, 0.0) > 0
+--
+-- Because migration 033 added causal_weight with DEFAULT 0.5, the second
+-- branch (COALESCE(e.causal_weight, 0.0) > 0) is always TRUE for every edge
+-- in the database.  As a result every edge received a metadata row, regardless
+-- of whether its relationship type carries any genuine causal semantics.
+--
+-- Fix
+-- ---
+-- 1. DELETE spurious rows whose edge_type is not in the causal-worthy set.
+-- 2. UPDATE the rows for EXTENDS / ELABORATES (which legitimately belong but
+--    received the generic ELSE-branch defaults) with better calibrated values.
+--
+-- Causal-worthy edge types (derived from the 034 explicit whitelist plus the
+-- causal-intent filter defined in migration 035 stored procedures):
+--
+--   Provenance / intervention : ORIGINATES, COMPILED_FROM, SUPERSEDES
+--   Epistemic / association   : CONFIRMS, CONTRADICTS, CONTENDS
+--   Explicit causal           : CAUSES, MOTIVATED_BY, IMPLEMENTS
+--   Elaborative (kept)        : EXTENDS, ELABORATES
+--
+-- All other types (structural, temporal, semantic, entity, quality) are
+-- removed.
+
+BEGIN;
+
+-- =============================================================================
+-- Step 1: Remove spurious rows for non-causal edge types
+-- =============================================================================
+
+DELETE FROM covalence.edge_causal_metadata ecm
+USING covalence.edges e
+WHERE ecm.edge_id = e.id
+  AND LOWER(e.edge_type) NOT IN (
+      'originates',
+      'compiled_from',
+      'supersedes',
+      'confirms',
+      'contradicts',
+      'contends',
+      'causes',
+      'motivated_by',
+      'implements',
+      'extends',
+      'elaborates'
+  );
+
+-- =============================================================================
+-- Step 2: Correct the EXTENDS / ELABORATES rows that were seeded with the
+--         generic ELSE-branch defaults (causal_strength=0.5, direction_conf=0.5,
+--         hidden_conf_risk=0.5, evidence_type='structural_prior').
+--         EXTENDS is an elaborative provenance edge — assign values consistent
+--         with how CONFIRMS is treated (association-level, moderate strength).
+-- =============================================================================
+
+UPDATE covalence.edge_causal_metadata ecm
+SET
+    causal_level     = 'association',
+    causal_strength  = 0.55,
+    evidence_type    = 'structural_prior',
+    direction_conf   = 0.75,
+    hidden_conf_risk = 0.30,
+    updated_at       = NOW()
+FROM covalence.edges e
+WHERE ecm.edge_id = e.id
+  AND LOWER(e.edge_type) IN ('extends', 'elaborates');
+
+COMMIT;


### PR DESCRIPTION
## Problem

Migration 034 bootstrapped `edge_causal_metadata` with a predicate that had two arms:

```sql
WHERE LOWER(e.edge_type) IN ('originates', 'compiled_from', 'supersedes',
                              'confirms', 'contradicts', 'contends', 'causes')
   OR COALESCE(e.causal_weight, 0.0) > 0
```

The second arm is always `TRUE`: migration 033 added `causal_weight` with `DEFAULT 0.5`, so `COALESCE(e.causal_weight, 0.0) > 0` evaluates to `0.5 > 0 = true` for every row. The result is that all 46,900+ edges in the database received a metadata row — including structural (`SPLIT_INTO`, `MERGED_FROM`), temporal (`CONCURRENT_WITH`), semantic (`RELATES_TO`), and review (`CRITIQUES`) edge types that carry no causal semantics.

## Fix — migration 036

A new migration (`036_fix_edge_causal_metadata_bootstrap.sql`) performs two operations inside a single transaction:

**Step 1 — DELETE spurious rows**

Removes metadata rows for any edge whose type is not in the causal-worthy set:

| Removed type | Row count | Reason |
|---|---|---|
| `RELATES_TO` | 1 265 | generic semantic edge |
| `EXTENDS` / `ELABORATES` | — | kept (see step 2) |
| `CONCURRENT_WITH` | 20 | temporal, not causal |
| `CRITIQUES` | 18 | quality/review edge |
| `DERIVES_FROM` | 11 | not in original whitelist |
| `SPLIT_INTO` | 8 | structural edge |
| `MERGED_FROM` | 6 | structural edge |
| **Total deleted** | **1 328** | |

Retained causal-worthy types: `ORIGINATES`, `COMPILED_FROM`, `SUPERSEDES`, `CONFIRMS`, `CONTRADICTS`, `CONTENDS`, `CAUSES`, `MOTIVATED_BY`, `IMPLEMENTS`, `EXTENDS`, `ELABORATES`.

**Step 2 — Re-calibrate EXTENDS / ELABORATES rows**

These 1 045 rows legitimately belong (elaborative provenance edges warrant causal metadata) but received the generic `ELSE`-branch defaults from 034. They are updated to values consistent with their association-level semantics (`causal_strength = 0.55`, `direction_conf = 0.75`, `hidden_conf_risk = 0.30`).

## Verification

- SQL dry-ran against the live DB inside a rolled-back transaction: `DELETE 1328`, `UPDATE 1045` — matches the expected counts exactly.
- `cargo check` passes with no new errors or warnings.
- No Rust source files modified; this is a pure migration addition.