### PR TITLE
feat(confidence): Phase 1 confidence propagation — DS fusion + DF-QuAD + SUPERSEDES decay (closes #137)

### DIFF
--- a/engine/migrations/037_confidence_propagation.sql
+++ b/engine/migrations/037_confidence_propagation.sql
@@ -1,0 +1,94 @@
+-- Migration 037: Confidence Propagation Phase 1 — schema additions (covalence#137)
+--
+-- Creates the article_sources provenance bridge table used by the DS-fusion /
+-- DF-QuAD / SUPERSEDES-decay pipeline, and adds the confidence_breakdown JSONB
+-- column to articles (stored in covalence.nodes).
+
+BEGIN;
+
+-- =============================================================================
+-- 1.  covalence.article_sources
+--     Maps source nodes → article nodes with relationship semantics and
+--     per-link provenance weights consumed by recompute_article_confidence().
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS covalence.article_sources (
+    article_id           UUID          NOT NULL
+                           REFERENCES covalence.nodes(id) ON DELETE CASCADE,
+    source_id            UUID          NOT NULL
+                           REFERENCES covalence.nodes(id) ON DELETE CASCADE,
+
+    -- Provenance relationship class.  Matches EdgeType label (lower-case).
+    relationship         TEXT          NOT NULL
+                           CONSTRAINT article_sources_relationship_check
+                           CHECK (relationship IN (
+                               'originates', 'compiled_from',
+                               'confirms', 'supersedes',
+                               'contradicts', 'contends'
+                           )),
+
+    -- Per-link weight inherited from the backing edge (defaults match EdgeType::causal_weight()).
+    causal_weight        REAL          NOT NULL DEFAULT 1.0
+                           CONSTRAINT article_sources_causal_weight_range
+                           CHECK (causal_weight >= 0.0 AND causal_weight <= 1.0),
+
+    -- Epistemological confidence in the link itself (e.g. LLM certainty score).
+    confidence           REAL          NOT NULL DEFAULT 1.0
+                           CONSTRAINT article_sources_confidence_range
+                           CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    -- Computed per-source contribution to the article's DS-fusion score.
+    -- Written by recompute_article_confidence(); NULL until first computed.
+    contribution_weight  REAL
+                           CONSTRAINT article_sources_contribution_weight_range
+                           CHECK (contribution_weight IS NULL
+                                  OR (contribution_weight >= 0.0
+                                      AND contribution_weight <= 1.0)),
+
+    -- Reserved for Phase 2 temporal decay: timestamp when this link was superseded.
+    -- NULL = link is still active.  NOT read in Phase 1.
+    superseded_at        TIMESTAMPTZ,
+
+    added_at             TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+    PRIMARY KEY (article_id, source_id, relationship)
+);
+
+COMMENT ON TABLE covalence.article_sources IS
+    'Provenance bridge between source nodes and article nodes. '
+    'Consumed by Phase-1 confidence propagation (covalence#137).';
+
+-- =============================================================================
+-- 2.  Partial indexes on article_sources
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_article_sources_article_relationship
+    ON covalence.article_sources (article_id, relationship)
+    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes');
+
+CREATE INDEX IF NOT EXISTS idx_article_sources_source_relationship
+    ON covalence.article_sources (source_id, relationship)
+    WHERE relationship IN ('supersedes', 'contradicts', 'contends');
+
+-- =============================================================================
+-- 3.  Add confidence_breakdown to article nodes (covalence.nodes)
+-- =============================================================================
+
+ALTER TABLE covalence.nodes
+    ADD COLUMN IF NOT EXISTS confidence_breakdown JSONB;
+
+COMMENT ON COLUMN covalence.nodes.confidence_breakdown IS
+    'Structured computation provenance from the last recompute_article_confidence() '
+    'run: DS-fusion, DF-QuAD penalty, supersedes-decay, flags, uncertainty interval.';
+
+COMMIT;
+
+-- =============================================================================
+-- DOWN
+-- =============================================================================
+-- To roll back:
+--
+--   ALTER TABLE covalence.nodes DROP COLUMN IF EXISTS confidence_breakdown;
+--   DROP INDEX IF EXISTS covalence.idx_article_sources_source_relationship;
+--   DROP INDEX IF EXISTS covalence.idx_article_sources_article_relationship;
+--   DROP TABLE IF EXISTS covalence.article_sources;

--- a/engine/migrations/037_confidence_propagation.sql
+++ b/engine/migrations/037_confidence_propagation.sql
@@ -27,7 +27,10 @@ CREATE TABLE IF NOT EXISTS covalence.article_sources (
                                'contradicts', 'contends'
                            )),
 
-    -- Per-link weight inherited from the backing edge (defaults match EdgeType::causal_weight()).
+    -- Per-link weight inherited from the backing edge.
+    -- Writers MUST always supply an explicit value; the DEFAULT 1.0 does not
+    -- match EdgeType::causal_weight() for most relationship types and exists
+    -- only as a schema-level safety net.
     causal_weight        REAL          NOT NULL DEFAULT 1.0
                            CONSTRAINT article_sources_causal_weight_range
                            CHECK (causal_weight >= 0.0 AND causal_weight <= 1.0),
@@ -64,11 +67,13 @@ COMMENT ON TABLE covalence.article_sources IS
 
 CREATE INDEX IF NOT EXISTS idx_article_sources_article_relationship
     ON covalence.article_sources (article_id, relationship)
-    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes');
+    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes')
+      AND superseded_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_article_sources_source_relationship
     ON covalence.article_sources (source_id, relationship)
-    WHERE relationship IN ('supersedes', 'contradicts', 'contends');
+    WHERE relationship IN ('supersedes', 'contradicts', 'contends')
+      AND superseded_at IS NULL;
 
 -- =============================================================================
 -- 3.  Add confidence_breakdown to article nodes (covalence.nodes)

--- a/engine/src/confidence/constants.rs
+++ b/engine/src/confidence/constants.rs
@@ -1,0 +1,11 @@
+//! Numeric constants for confidence propagation (covalence#137).
+
+/// Hard lower bound applied after the full propagation pipeline.
+/// Ensures no article ever reaches zero confidence (epistemic humility floor).
+pub const CONF_FLOOR: f64 = 0.02;
+
+/// Default edge weight for CONTRADICTS attackers in DF-QuAD penalty.
+pub const CONTRADICTS_DEFAULT_WEIGHT: f64 = 1.0;
+
+/// Default edge weight for CONTENDS attackers in DF-QuAD penalty.
+pub const CONTENDS_DEFAULT_WEIGHT: f64 = 0.3;

--- a/engine/src/confidence/constants.rs
+++ b/engine/src/confidence/constants.rs
@@ -5,10 +5,10 @@
 pub const CONF_FLOOR: f64 = 0.02;
 
 // ── Test-only fixtures ────────────────────────────────────────────────────────
-// These constants are reference values for unit tests, not production defaults.
+// These constants are reference values for integration tests, not production defaults.
 // Edge weights in production are read from `covalence.article_sources.causal_weight`.
-#[cfg(test)]
+// Note: not gated by #[cfg(test)] because integration tests compile against the
+// library in non-test mode and cannot access #[cfg(test)]-gated items.
 pub const TEST_CONTRADICTS_DEFAULT_WEIGHT: f64 = 1.0;
 
-#[cfg(test)]
 pub const TEST_CONTENDS_DEFAULT_WEIGHT: f64 = 0.3;

--- a/engine/src/confidence/constants.rs
+++ b/engine/src/confidence/constants.rs
@@ -4,8 +4,11 @@
 /// Ensures no article ever reaches zero confidence (epistemic humility floor).
 pub const CONF_FLOOR: f64 = 0.02;
 
-/// Default edge weight for CONTRADICTS attackers in DF-QuAD penalty.
-pub const CONTRADICTS_DEFAULT_WEIGHT: f64 = 1.0;
+// ── Test-only fixtures ────────────────────────────────────────────────────────
+// These constants are reference values for unit tests, not production defaults.
+// Edge weights in production are read from `covalence.article_sources.causal_weight`.
+#[cfg(test)]
+pub const TEST_CONTRADICTS_DEFAULT_WEIGHT: f64 = 1.0;
 
-/// Default edge weight for CONTENDS attackers in DF-QuAD penalty.
-pub const CONTENDS_DEFAULT_WEIGHT: f64 = 0.3;
+#[cfg(test)]
+pub const TEST_CONTENDS_DEFAULT_WEIGHT: f64 = 0.3;

--- a/engine/src/confidence/dfquad_penalty.rs
+++ b/engine/src/confidence/dfquad_penalty.rs
@@ -1,0 +1,67 @@
+//! DF-QuAD contradiction penalty for confidence propagation (covalence#137).
+//!
+//! Models how attacking arguments (CONTRADICTS / CONTENDS edges) reduce
+//! the confidence accumulated from the DS-fusion step.
+
+/// Apply DF-QuAD attack penalty to a base confidence.
+///
+/// `attackers` is a slice of `(trust_score, edge_weight)` pairs where each
+/// entry represents one attacking node B and its edge weight `w(B→A)`.
+///
+/// ```text
+/// attack_contribution(Bⱼ→A) = trust_score(Bⱼ) × w(Bⱼ→A)   [clamped to [0,1]]
+/// total_attack = 1 − ∏(1 − attack_contribution(Bⱼ→A))
+/// conf_after_penalty = base_conf × (1 − total_attack)
+/// ```
+///
+/// Returns `base_conf` unchanged when the attacker list is empty.
+pub fn dfquad_penalty(base_conf: f64, attackers: &[(f64, f64)]) -> f64 {
+    if attackers.is_empty() {
+        return base_conf;
+    }
+
+    let complement_product = attackers.iter().fold(1.0_f64, |acc, &(trust, weight)| {
+        acc * (1.0 - (trust * weight).clamp(0.0, 1.0))
+    });
+
+    let total_attack = 1.0 - complement_product;
+    base_conf * (1.0 - total_attack)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_attackers_identity() {
+        assert!((dfquad_penalty(0.9, &[]) - 0.9).abs() < 1e-12);
+    }
+
+    #[test]
+    fn single_contradicts_attacker() {
+        // base=0.9, trust=0.8, w=1.0 → total_attack=0.8 → conf=0.9×0.2=0.18
+        let result = dfquad_penalty(0.9, &[(0.8, 1.0)]);
+        assert!((result - 0.18).abs() < 1e-9, "got {result}");
+    }
+
+    #[test]
+    fn contends_less_damaging_than_contradicts() {
+        let base = 0.9;
+        let trust = 0.8;
+        let contradicts = dfquad_penalty(base, &[(trust, 1.0)]);
+        let contends = dfquad_penalty(base, &[(trust, 0.3)]);
+        assert!(
+            contends > contradicts,
+            "contends ({contends}) should be less damaging than contradicts ({contradicts})"
+        );
+    }
+
+    #[test]
+    fn zero_attack_leaves_base_unchanged() {
+        // trust=0.0 → contribution=0 → total_attack=0 → unchanged
+        let result = dfquad_penalty(0.7, &[(0.0, 1.0)]);
+        assert!((result - 0.7).abs() < 1e-12);
+    }
+}

--- a/engine/src/confidence/ds_fusion.rs
+++ b/engine/src/confidence/ds_fusion.rs
@@ -1,0 +1,65 @@
+//! Dempster-Shafer multi-source fusion for confidence propagation (covalence#137).
+//!
+//! Implements the complement-product formula for combining independent
+//! evidence sources into a single belief score.
+
+/// Fuse a slice of effective per-source reliabilities into a single DS score.
+///
+/// Each element of `source_reliabilities` is an **already-computed**
+/// effective reliability `r_i ∈ [0, 1]` for source *i*:
+///
+/// ```text
+/// conf_ds = 1 − ∏(1 − rᵢ)
+/// ```
+///
+/// Special cases:
+/// * Empty slice → `0.0` (no evidence → no belief).
+/// * Single element → that element's value.
+/// * All elements are clamped to `[0.0, 1.0]` before use.
+pub fn ds_fusion(source_reliabilities: &[f64]) -> f64 {
+    if source_reliabilities.is_empty() {
+        return 0.0;
+    }
+
+    let complement_product = source_reliabilities
+        .iter()
+        .fold(1.0_f64, |acc, &r| acc * (1.0 - r.clamp(0.0, 1.0)));
+
+    1.0 - complement_product
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_returns_zero() {
+        assert_eq!(ds_fusion(&[]), 0.0);
+    }
+
+    #[test]
+    fn single_source_identity() {
+        assert!((ds_fusion(&[0.75]) - 0.75).abs() < 1e-12);
+    }
+
+    #[test]
+    fn three_sources_complement_product() {
+        // 1 − (0.2 × 0.3 × 0.4) = 1 − 0.024 = 0.976
+        let result = ds_fusion(&[0.8, 0.7, 0.6]);
+        assert!((result - 0.976).abs() < 1e-9, "got {result}");
+    }
+
+    #[test]
+    fn clamps_values_above_one() {
+        // Should treat 1.5 as 1.0 → complement = 0 → result = 1.0
+        assert_eq!(ds_fusion(&[1.5]), 1.0);
+    }
+
+    #[test]
+    fn clamps_values_below_zero() {
+        // Should treat -0.5 as 0.0 → complement = 1 → result = 0.0
+        assert_eq!(ds_fusion(&[-0.5]), 0.0);
+    }
+}

--- a/engine/src/confidence/mod.rs
+++ b/engine/src/confidence/mod.rs
@@ -1,0 +1,34 @@
+//! Confidence propagation — Phase 1 (covalence#137).
+//!
+//! Three-phase pipeline:
+//! * **Phase 1A** — Dempster-Shafer multi-source fusion over ORIGINATES links.
+//! * **Phase 1B** — DF-QuAD contradiction penalty from CONTRADICTS / CONTENDS.
+//! * **Phase 1C** — SUPERSEDES decay applied last.
+//!
+//! Public entry-point: [`recompute::recompute_article_confidence`].
+
+pub mod constants;
+pub mod dfquad_penalty;
+pub mod ds_fusion;
+pub mod recompute;
+pub mod supersedes_decay;
+
+pub use recompute::recompute_article_confidence;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// Structured result returned by [`recompute_article_confidence`].
+#[derive(Debug, Clone)]
+pub struct ConfidenceResult {
+    /// The article whose confidence was recomputed.
+    pub article_id: Uuid,
+    /// Final clamped score in `[CONF_FLOOR, 1.0]` written to the article.
+    pub final_score: f64,
+    /// Full JSON breakdown persisted to `covalence.nodes.confidence_breakdown`.
+    pub breakdown: serde_json::Value,
+    /// Diagnostic flags (e.g. `"no_sources"`, `"floor_clamped"`).
+    pub flags: Vec<String>,
+    /// Timestamp of this computation run.
+    pub computed_at: DateTime<Utc>,
+}

--- a/engine/src/confidence/recompute.rs
+++ b/engine/src/confidence/recompute.rs
@@ -10,10 +10,7 @@ use sqlx::PgConnection;
 use uuid::Uuid;
 
 use super::{
-    ConfidenceResult,
-    constants::{CONF_FLOOR, CONTENDS_DEFAULT_WEIGHT, CONTRADICTS_DEFAULT_WEIGHT},
-    dfquad_penalty::dfquad_penalty,
-    ds_fusion::ds_fusion,
+    ConfidenceResult, constants::CONF_FLOOR, dfquad_penalty::dfquad_penalty, ds_fusion::ds_fusion,
     supersedes_decay::supersedes_decay,
 };
 
@@ -62,9 +59,14 @@ pub async fn recompute_article_confidence(
         use sqlx::Row;
         let sid: Uuid = row.try_get("source_id")?;
         // reliability is DOUBLE PRECISION on nodes; causal_weight / conf_link are REAL on article_sources.
+        // causal_weight and conf_link are NOT NULL; COALESCE in SQL is belt-and-suspenders.
         let rel: f64 = row.try_get("reliability").unwrap_or(0.5);
-        let cw: f64 = row.try_get::<f32, _>("causal_weight").unwrap_or(1.0) as f64;
-        let cl: f64 = row.try_get::<f32, _>("conf_link").unwrap_or(1.0) as f64;
+        let cw: f64 = row
+            .try_get::<f32, _>("causal_weight")
+            .expect("causal_weight is NOT NULL") as f64;
+        let cl: f64 = row
+            .try_get::<f32, _>("conf_link")
+            .expect("confidence is NOT NULL") as f64;
         let eff = (rel * cw * cl).clamp(0.0, 1.0);
         source_ids.push(sid);
         source_eff_reliabilities.push(eff);
@@ -100,20 +102,10 @@ pub async fn recompute_article_confidence(
     for row in &attack_rows {
         use sqlx::Row;
         let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
-        let rel_str: String = row.try_get("relationship").unwrap_or_default();
-        let default_w = if rel_str == "contradicts" {
-            CONTRADICTS_DEFAULT_WEIGHT
-        } else {
-            CONTENDS_DEFAULT_WEIGHT
-        };
-        // Prefer causal_weight override when present and non-null.
-        // Column is REAL (f32) in Postgres; cast to f64 after extraction.
+        // causal_weight is NOT NULL; read directly as f32 and widen to f64.
         let w: f64 = row
-            .try_get::<Option<f32>, _>("causal_weight")
-            .ok()
-            .flatten()
-            .map(|v| v as f64)
-            .unwrap_or(default_w);
+            .try_get::<f32, _>("causal_weight")
+            .expect("causal_weight is NOT NULL") as f64;
         attackers.push((trust, w));
     }
 
@@ -151,8 +143,11 @@ pub async fn recompute_article_confidence(
     for row in &supersedes_rows {
         use sqlx::Row;
         let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
-        // causal_weight column is REAL (f32); read as f32 then widen.
-        let cw: f64 = row.try_get::<f32, _>("causal_weight").unwrap_or(1.0) as f64;
+        // causal_weight is NOT NULL; COALESCE in SQL is belt-and-suspenders.
+        // Read as f32 (REAL column) then widen to f64.
+        let cw: f64 = row
+            .try_get::<f32, _>("causal_weight")
+            .expect("causal_weight is NOT NULL") as f64;
         supersedes_pairs.push((trust, cw));
     }
 

--- a/engine/src/confidence/recompute.rs
+++ b/engine/src/confidence/recompute.rs
@@ -61,12 +61,8 @@ pub async fn recompute_article_confidence(
         // reliability is DOUBLE PRECISION on nodes; causal_weight / conf_link are REAL on article_sources.
         // causal_weight and conf_link are NOT NULL; COALESCE in SQL is belt-and-suspenders.
         let rel: f64 = row.try_get("reliability").unwrap_or(0.5);
-        let cw: f64 = row
-            .try_get::<f32, _>("causal_weight")
-            .expect("causal_weight is NOT NULL") as f64;
-        let cl: f64 = row
-            .try_get::<f32, _>("conf_link")
-            .expect("confidence is NOT NULL") as f64;
+        let cw: f64 = row.try_get::<f32, _>("causal_weight")? as f64;
+        let cl: f64 = row.try_get::<f32, _>("conf_link")? as f64;
         let eff = (rel * cw * cl).clamp(0.0, 1.0);
         source_ids.push(sid);
         source_eff_reliabilities.push(eff);
@@ -103,9 +99,7 @@ pub async fn recompute_article_confidence(
         use sqlx::Row;
         let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
         // causal_weight is NOT NULL; read directly as f32 and widen to f64.
-        let w: f64 = row
-            .try_get::<f32, _>("causal_weight")
-            .expect("causal_weight is NOT NULL") as f64;
+        let w: f64 = row.try_get::<f32, _>("causal_weight")? as f64;
         attackers.push((trust, w));
     }
 
@@ -145,9 +139,7 @@ pub async fn recompute_article_confidence(
         let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
         // causal_weight is NOT NULL; COALESCE in SQL is belt-and-suspenders.
         // Read as f32 (REAL column) then widen to f64.
-        let cw: f64 = row
-            .try_get::<f32, _>("causal_weight")
-            .expect("causal_weight is NOT NULL") as f64;
+        let cw: f64 = row.try_get::<f32, _>("causal_weight")? as f64;
         supersedes_pairs.push((trust, cw));
     }
 
@@ -176,7 +168,9 @@ pub async fn recompute_article_confidence(
     // Bel = conf_ds (committed belief mass).
     // Pl  = Bel + (1 − Bel)  (belief + uncommitted mass — epistemic upper bound).
     let bel = conf_ds;
-    let pl = conf_ds + (1.0 - conf_ds); // always 1.0 in classic two-valued DS
+    // TODO: make configurable — in a richer DS model, Pl could be < 1.0 when
+    // uncertainty mass is distributed across multiple hypotheses.
+    let pl = 1.0_f64; // always 1.0 in classic two-valued DS
 
     // ── Build confidence_breakdown JSON ──────────────────────────────────────
     let breakdown = serde_json::json!({
@@ -235,7 +229,7 @@ pub async fn recompute_article_confidence(
         article_id,
         final_score,
         breakdown,
-        flags: flags.clone(),
+        flags,
         computed_at,
     })
 }

--- a/engine/src/confidence/recompute.rs
+++ b/engine/src/confidence/recompute.rs
@@ -1,0 +1,246 @@
+//! `recompute_article_confidence` — the three-phase pipeline (covalence#137).
+//!
+//! Runs Phase 1A (DS fusion), 1B (DF-QuAD penalty), and 1C (SUPERSEDES decay)
+//! in sequence, writes the result to `covalence.nodes.confidence` and
+//! `covalence.nodes.confidence_breakdown`, and back-fills
+//! `covalence.article_sources.contribution_weight` for ORIGINATES rows.
+
+use chrono::Utc;
+use sqlx::PgConnection;
+use uuid::Uuid;
+
+use super::{
+    ConfidenceResult,
+    constants::{CONF_FLOOR, CONTENDS_DEFAULT_WEIGHT, CONTRADICTS_DEFAULT_WEIGHT},
+    dfquad_penalty::dfquad_penalty,
+    ds_fusion::ds_fusion,
+    supersedes_decay::supersedes_decay,
+};
+
+/// Recompute the confidence score for a single article.
+///
+/// Reads provenance links from `covalence.article_sources` and applies:
+/// * **Phase 1A** — Dempster-Shafer fusion over ORIGINATES sources.
+/// * **Phase 1B** — DF-QuAD penalty from CONTRADICTS / CONTENDS sources.
+/// * **Phase 1C** — SUPERSEDES decay from sources that supersede this article.
+///
+/// The final score is clamped to `[CONF_FLOOR, 1.0]` and written to
+/// `covalence.nodes.confidence`.  A structured [`ConfidenceResult`] is
+/// returned so callers can log or forward the breakdown.
+///
+/// # Errors
+/// Returns any database error encountered during the read or write queries.
+pub async fn recompute_article_confidence(
+    article_id: Uuid,
+    conn: &mut PgConnection,
+) -> anyhow::Result<ConfidenceResult> {
+    // ── Phase 1A: Dempster-Shafer multi-source fusion ─────────────────────────
+    //
+    // effective_reliability(S) = sources.reliability × article_sources.causal_weight
+    //                            × article_sources.confidence
+    let orig_rows = sqlx::query(
+        "SELECT
+             s.source_id,
+             COALESCE(n.reliability, 0.5)  AS reliability,
+             COALESCE(s.causal_weight, 1.0) AS causal_weight,
+             COALESCE(s.confidence, 1.0)    AS conf_link
+         FROM covalence.article_sources s
+         JOIN covalence.nodes n ON n.id = s.source_id
+         WHERE s.article_id  = $1
+           AND s.relationship IN ('originates', 'compiled_from')
+           AND s.superseded_at IS NULL",
+    )
+    .bind(article_id)
+    .fetch_all(&mut *conn)
+    .await?;
+
+    let mut source_ids: Vec<Uuid> = Vec::with_capacity(orig_rows.len());
+    let mut source_eff_reliabilities: Vec<f64> = Vec::with_capacity(orig_rows.len());
+    let mut flags: Vec<String> = Vec::new();
+
+    for row in &orig_rows {
+        use sqlx::Row;
+        let sid: Uuid = row.try_get("source_id")?;
+        // reliability is DOUBLE PRECISION on nodes; causal_weight / conf_link are REAL on article_sources.
+        let rel: f64 = row.try_get("reliability").unwrap_or(0.5);
+        let cw: f64 = row.try_get::<f32, _>("causal_weight").unwrap_or(1.0) as f64;
+        let cl: f64 = row.try_get::<f32, _>("conf_link").unwrap_or(1.0) as f64;
+        let eff = (rel * cw * cl).clamp(0.0, 1.0);
+        source_ids.push(sid);
+        source_eff_reliabilities.push(eff);
+    }
+
+    if source_ids.is_empty() {
+        flags.push("no_sources".into());
+    }
+
+    let conf_ds = ds_fusion(&source_eff_reliabilities);
+
+    // ── Phase 1B: DF-QuAD contradiction penalty ───────────────────────────────
+    //
+    // attack_contribution(B→A) = trust_score(B) × w(B→A)
+    // Use causal_weight from article_sources as edge weight when non-null.
+    let attack_rows = sqlx::query(
+        "SELECT
+             COALESCE(n.confidence, 0.5) AS trust_score,
+             s.causal_weight,
+             s.relationship
+         FROM covalence.article_sources s
+         JOIN covalence.nodes n ON n.id = s.source_id
+         WHERE s.article_id  = $1
+           AND s.relationship IN ('contradicts', 'contends')
+           AND s.superseded_at IS NULL",
+    )
+    .bind(article_id)
+    .fetch_all(&mut *conn)
+    .await?;
+
+    let mut attackers: Vec<(f64, f64)> = Vec::with_capacity(attack_rows.len());
+
+    for row in &attack_rows {
+        use sqlx::Row;
+        let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
+        let rel_str: String = row.try_get("relationship").unwrap_or_default();
+        let default_w = if rel_str == "contradicts" {
+            CONTRADICTS_DEFAULT_WEIGHT
+        } else {
+            CONTENDS_DEFAULT_WEIGHT
+        };
+        // Prefer causal_weight override when present and non-null.
+        // Column is REAL (f32) in Postgres; cast to f64 after extraction.
+        let w: f64 = row
+            .try_get::<Option<f32>, _>("causal_weight")
+            .ok()
+            .flatten()
+            .map(|v| v as f64)
+            .unwrap_or(default_w);
+        attackers.push((trust, w));
+    }
+
+    let conf_after_penalty = dfquad_penalty(conf_ds, &attackers);
+
+    // Pre-compute total_attack for the breakdown JSON.
+    let total_attack = if attackers.is_empty() {
+        0.0_f64
+    } else {
+        let cp = attackers.iter().fold(1.0_f64, |acc, &(t, w)| {
+            acc * (1.0 - (t * w).clamp(0.0, 1.0))
+        });
+        1.0 - cp
+    };
+
+    // ── Phase 1C: SUPERSEDES decay ────────────────────────────────────────────
+    //
+    // supersede_factor(B→A) = trust_score(B) × causal_weight (default=1.0)
+    let supersedes_rows = sqlx::query(
+        "SELECT
+             COALESCE(n.confidence, 0.5)   AS trust_score,
+             COALESCE(s.causal_weight, 1.0) AS causal_weight
+         FROM covalence.article_sources s
+         JOIN covalence.nodes n ON n.id = s.source_id
+         WHERE s.article_id  = $1
+           AND s.relationship = 'supersedes'
+           AND s.superseded_at IS NULL",
+    )
+    .bind(article_id)
+    .fetch_all(&mut *conn)
+    .await?;
+
+    let mut supersedes_pairs: Vec<(f64, f64)> = Vec::with_capacity(supersedes_rows.len());
+
+    for row in &supersedes_rows {
+        use sqlx::Row;
+        let trust: f64 = row.try_get("trust_score").unwrap_or(0.5);
+        // causal_weight column is REAL (f32); read as f32 then widen.
+        let cw: f64 = row.try_get::<f32, _>("causal_weight").unwrap_or(1.0) as f64;
+        supersedes_pairs.push((trust, cw));
+    }
+
+    let conf_after_decay = supersedes_decay(conf_after_penalty, &supersedes_pairs);
+
+    let total_supersede = if supersedes_pairs.is_empty() {
+        0.0_f64
+    } else {
+        let cp = supersedes_pairs.iter().fold(1.0_f64, |acc, &(t, w)| {
+            acc * (1.0 - (t * w).clamp(0.0, 1.0))
+        });
+        1.0 - cp
+    };
+
+    // ── Final: clamp to [CONF_FLOOR, 1.0] ────────────────────────────────────
+    let was_clamped = conf_after_decay < CONF_FLOOR;
+    let final_score = conf_after_decay.clamp(CONF_FLOOR, 1.0);
+
+    if was_clamped {
+        flags.push("floor_clamped".into());
+    }
+
+    let computed_at = Utc::now();
+
+    // Uncertainty interval from DS theory: [Bel, Pl].
+    // Bel = conf_ds (committed belief mass).
+    // Pl  = Bel + (1 − Bel)  (belief + uncommitted mass — epistemic upper bound).
+    let bel = conf_ds;
+    let pl = conf_ds + (1.0 - conf_ds); // always 1.0 in classic two-valued DS
+
+    // ── Build confidence_breakdown JSON ──────────────────────────────────────
+    let breakdown = serde_json::json!({
+        "ds_fusion": {
+            "source_count": source_eff_reliabilities.len(),
+            "source_reliabilities": source_eff_reliabilities,
+            "raw_score": conf_ds,
+        },
+        "contradicts_penalty": {
+            "attacker_count": attackers.len(),
+            "total_attack": total_attack,
+            "score_after": conf_after_penalty,
+        },
+        "supersedes_decay": {
+            "superseder_count": supersedes_pairs.len(),
+            "total_supersede": total_supersede,
+            "score_after": conf_after_decay,
+        },
+        "final_score": final_score,
+        "uncertainty_interval": [bel, pl],
+        "flags": flags,
+        "computed_at": computed_at.to_rfc3339(),
+    });
+
+    // ── Persist: write trust_score + breakdown to the article node ─────────
+    sqlx::query(
+        "UPDATE covalence.nodes
+         SET confidence           = $1,
+             confidence_breakdown = $2,
+             modified_at          = now()
+         WHERE id = $3",
+    )
+    .bind(final_score)
+    .bind(&breakdown)
+    .bind(article_id)
+    .execute(&mut *conn)
+    .await?;
+
+    // ── Persist: back-fill contribution_weight on ORIGINATES rows ─────────
+    for (sid, &eff_rel) in source_ids.iter().zip(source_eff_reliabilities.iter()) {
+        sqlx::query(
+            "UPDATE covalence.article_sources
+             SET contribution_weight = $1
+             WHERE article_id  = $2
+               AND source_id   = $3
+               AND relationship IN ('originates', 'compiled_from')",
+        )
+        .bind(eff_rel as f32)
+        .bind(article_id)
+        .bind(sid)
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(ConfidenceResult {
+        article_id,
+        final_score,
+        breakdown,
+        flags: flags.clone(),
+        computed_at,
+    })
+}

--- a/engine/src/confidence/supersedes_decay.rs
+++ b/engine/src/confidence/supersedes_decay.rs
@@ -1,0 +1,60 @@
+//! SUPERSEDES temporal decay for confidence propagation (covalence#137).
+//!
+//! When a source explicitly supersedes an article it reduces the article's
+//! confidence using the same complement-product formula as DF-QuAD.
+
+/// Apply SUPERSEDES decay to a base confidence.
+///
+/// `supersedes` is a slice of `(trust_score, causal_weight)` pairs where each
+/// entry represents one superseding node B and its edge causal weight.
+///
+/// ```text
+/// supersede_factor(Bₖ→A) = trust_score(Bₖ) × causal_weight(edge)  [clamped to [0,1]]
+/// total_supersede = 1 − ∏(1 − supersede_factor(Bₖ→A))
+/// conf_after_decay = base_conf × (1 − total_supersede)
+/// ```
+///
+/// Returns `base_conf` unchanged when the superseder list is empty.
+pub fn supersedes_decay(base_conf: f64, supersedes: &[(f64, f64)]) -> f64 {
+    if supersedes.is_empty() {
+        return base_conf;
+    }
+
+    let complement_product = supersedes.iter().fold(1.0_f64, |acc, &(trust, weight)| {
+        acc * (1.0 - (trust * weight).clamp(0.0, 1.0))
+    });
+
+    let total_supersede = 1.0 - complement_product;
+    base_conf * (1.0 - total_supersede)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_supersedes_identity() {
+        assert!((supersedes_decay(0.8, &[]) - 0.8).abs() < 1e-12);
+    }
+
+    #[test]
+    fn full_supersession_drives_to_zero() {
+        // trust=1.0, weight=1.0 → total=1.0 → result=0.0
+        let result = supersedes_decay(0.8, &[(1.0, 1.0)]);
+        assert!((result - 0.0).abs() < 1e-12, "got {result}");
+    }
+
+    #[test]
+    fn partial_supersession() {
+        // trust=0.6, weight=0.8 → factor=0.48 → total=0.48 → decay=0.485×0.52=0.2522
+        let base = 0.485;
+        let result = supersedes_decay(base, &[(0.6, 0.8)]);
+        let expected = base * (1.0 - 0.48);
+        assert!(
+            (result - expected).abs() < 1e-9,
+            "got {result}, expected {expected}"
+        );
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -2,6 +2,7 @@
 //! The binary entry-point remains `main.rs`.
 
 pub mod api;
+pub mod confidence;
 pub mod db;
 pub mod embeddings;
 pub mod errors;

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,4 +1,5 @@
 mod api;
+mod confidence;
 mod embeddings;
 mod errors;
 mod graph;

--- a/engine/src/services/admin_service.rs
+++ b/engine/src/services/admin_service.rs
@@ -275,6 +275,63 @@ impl AdminService {
                 result.rows_affected()
             ));
 
+            // Batch-recompute confidence for all stale articles (covalence#137).
+            // An article is stale when its article_sources provenance has changed
+            // since its confidence_breakdown was last computed.  For Phase 1 we
+            // recompute all active articles that have at least one article_sources
+            // row but whose confidence_breakdown is NULL (never computed yet).
+            let stale_ids: Vec<Uuid> = sqlx::query_scalar(
+                "SELECT DISTINCT a.id
+                 FROM covalence.nodes a
+                 WHERE a.node_type = 'article'
+                   AND a.status    = 'active'
+                   AND a.confidence_breakdown IS NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM covalence.article_sources s
+                       WHERE s.article_id = a.id
+                   )
+                 LIMIT 50",
+            )
+            .fetch_all(&self.pool)
+            .await
+            .unwrap_or_default();
+
+            let mut confidence_ok: usize = 0;
+            let mut confidence_err: usize = 0;
+            for article_id in &stale_ids {
+                match self.pool.acquire().await {
+                    Ok(mut conn) => {
+                        match crate::confidence::recompute_article_confidence(
+                            *article_id,
+                            &mut conn,
+                        )
+                        .await
+                        {
+                            Ok(_) => confidence_ok += 1,
+                            Err(e) => {
+                                tracing::warn!(
+                                    article_id = %article_id,
+                                    "process_queue: confidence recompute failed: {e:#}"
+                                );
+                                confidence_err += 1;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "process_queue: could not acquire conn for confidence recompute: {e:#}"
+                        );
+                        confidence_err += 1;
+                    }
+                }
+            }
+            if confidence_ok > 0 || confidence_err > 0 {
+                actions.push(format!(
+                    "confidence recompute: {confidence_ok} ok, {confidence_err} errors"
+                ));
+            }
+
             // Pass A + B — delegate to stored procedure (migration 035, covalence#143).
             // Fixes the two-pass DELETE with typed bind params (no format! interpolation).
             // Pass A: stale failed embed tasks for nodes that now have embeddings (>= 1 h).

--- a/engine/src/services/admin_service.rs
+++ b/engine/src/services/admin_service.rs
@@ -275,11 +275,12 @@ impl AdminService {
                 result.rows_affected()
             ));
 
-            // Batch-recompute confidence for all stale articles (covalence#137).
-            // An article is stale when its article_sources provenance has changed
-            // since its confidence_breakdown was last computed.  For Phase 1 we
-            // recompute all active articles that have at least one article_sources
-            // row but whose confidence_breakdown is NULL (never computed yet).
+            // Batch-recompute confidence for articles that have never had confidence
+            // computed (covalence#137).  The query selects active articles that have
+            // at least one article_sources row but whose confidence_breakdown is NULL,
+            // meaning the pipeline has never run for them — NOT that they are stale.
+            // True staleness detection (comparing provenance change time to last
+            // compute time) is future work tracked in covalence#137.
             let stale_ids: Vec<Uuid> = sqlx::query_scalar(
                 "SELECT DISTINCT a.id
                  FROM covalence.nodes a
@@ -299,12 +300,14 @@ impl AdminService {
 
             let mut confidence_ok: usize = 0;
             let mut confidence_err: usize = 0;
-            for article_id in &stale_ids {
-                match self.pool.acquire().await {
-                    Ok(mut conn) => {
+            // Acquire a single connection once and reuse it across all articles
+            // rather than hitting the pool for every iteration (fix #6).
+            match self.pool.acquire().await {
+                Ok(mut conn) => {
+                    for article_id in &stale_ids {
                         match crate::confidence::recompute_article_confidence(
                             *article_id,
-                            &mut conn,
+                            &mut *conn,
                         )
                         .await
                         {
@@ -318,12 +321,12 @@ impl AdminService {
                             }
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            "process_queue: could not acquire conn for confidence recompute: {e:#}"
-                        );
-                        confidence_err += 1;
-                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "process_queue: could not acquire conn for confidence recompute: {e:#}"
+                    );
+                    confidence_err += stale_ids.len();
                 }
             }
             if confidence_ok > 0 || confidence_err > 0 {

--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -1410,6 +1410,63 @@ SOURCE DOCUMENTS:\n\
         }
     }
 
+    // ── 7b. Mirror provenance edges into article_sources + recompute confidence ─
+    // Insert one row per source into covalence.article_sources so that the
+    // Phase-1 confidence pipeline (covalence#137) can query them.
+    // Uses ON CONFLICT DO NOTHING for idempotent re-runs.
+    for src in &sources {
+        let rel_str = rel_map
+            .get(&src.id)
+            .map(|s| s.as_str())
+            .unwrap_or("originates");
+        let causal_w: f32 = match rel_str {
+            "supersedes" => 0.95,
+            "confirms" => 0.60,
+            "contradicts" => 0.50,
+            "contends" => 0.30,
+            _ => 1.0, // originates
+        };
+        if let Err(e) = sqlx::query(
+            "INSERT INTO covalence.article_sources \
+             (article_id, source_id, relationship, causal_weight, confidence) \
+             VALUES ($1, $2, $3, $4, 1.0) \
+             ON CONFLICT (article_id, source_id, relationship) DO NOTHING",
+        )
+        .bind(article_id)
+        .bind(src.id)
+        .bind(rel_str)
+        .bind(causal_w)
+        .execute(pool)
+        .await
+        {
+            tracing::warn!(
+                article_id = %article_id,
+                source_id  = %src.id,
+                "compile: failed to mirror edge into article_sources (non-fatal): {e}"
+            );
+        }
+    }
+
+    // Trigger confidence recompute now that provenance links are written.
+    match pool.acquire().await {
+        Ok(mut conn) => {
+            if let Err(e) =
+                crate::confidence::recompute_article_confidence(article_id, &mut conn).await
+            {
+                tracing::warn!(
+                    article_id = %article_id,
+                    "compile: confidence recompute failed (non-fatal): {e:#}"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                article_id = %article_id,
+                "compile: could not acquire conn for confidence recompute: {e:#}"
+            );
+        }
+    }
+
     // ── 8. Queue follow-up tasks ────────────────────────────────────────────
     enqueue_task(pool, "embed", Some(article_id), json!({}), 5).await?;
     for src in &sources {

--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -1413,24 +1413,28 @@ SOURCE DOCUMENTS:\n\
     // ── 7b. Mirror provenance edges into article_sources + recompute confidence ─
     // Insert one row per source into covalence.article_sources so that the
     // Phase-1 confidence pipeline (covalence#137) can query them.
-    // Uses ON CONFLICT DO NOTHING for idempotent re-runs.
+    // Uses ON CONFLICT DO UPDATE so re-compiling an article refreshes weights
+    // rather than leaving stale causal_weight / confidence values.
     for src in &sources {
         let rel_str = rel_map
             .get(&src.id)
             .map(|s| s.as_str())
             .unwrap_or("originates");
-        let causal_w: f32 = match rel_str {
-            "supersedes" => 0.95,
-            "confirms" => 0.60,
-            "contradicts" => 0.50,
-            "contends" => 0.30,
-            _ => 1.0, // originates
-        };
+        // Derive causal_weight from EdgeType::causal_weight() so insertion
+        // weights stay in sync with the recompute pipeline (fix #1).
+        let causal_w: f32 = rel_str
+            .to_uppercase()
+            .parse::<crate::models::EdgeType>()
+            .map(|et| et.causal_weight())
+            .unwrap_or(1.0); // originates / unknown → 1.0
         if let Err(e) = sqlx::query(
             "INSERT INTO covalence.article_sources \
              (article_id, source_id, relationship, causal_weight, confidence) \
              VALUES ($1, $2, $3, $4, 1.0) \
-             ON CONFLICT (article_id, source_id, relationship) DO NOTHING",
+             ON CONFLICT (article_id, source_id, relationship) DO UPDATE \
+             SET causal_weight  = EXCLUDED.causal_weight, \
+                 confidence     = EXCLUDED.confidence, \
+                 superseded_at  = EXCLUDED.superseded_at",
         )
         .bind(article_id)
         .bind(src.id)

--- a/engine/tests/integration/main.rs
+++ b/engine/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod test_causal_semantics;
 mod test_compilation;
 mod test_compile;
 mod test_concerns;
+mod test_confidence_propagation;
 mod test_consolidation;
 mod test_content_hash;
 mod test_contention;

--- a/engine/tests/integration/test_confidence_propagation.rs
+++ b/engine/tests/integration/test_confidence_propagation.rs
@@ -1,0 +1,469 @@
+//! Integration tests for Phase-1 confidence propagation (covalence#137).
+//!
+//! Covers the seven required scenarios:
+//!
+//! 1. Single ORIGINATES source (reliability=0.75) → trust_score=0.75
+//! 2. Three sources ([0.8,0.7,0.6]) → trust_score=1−(0.2×0.3×0.4)=0.976
+//! 3. Zero sources → trust_score=CONF_FLOOR=0.02, flags=["no_sources"]
+//! 4. Single CONTRADICTS attacker (ds_base=0.9, trust=0.8, w=1.0) → 0.18
+//! 5. CONTENDS (w=0.3) vs CONTRADICTS (w=1.0) same strength → CONTENDS leaves more
+//! 6. Full supersession (B.trust=1.0, w=1.0) → clamped to CONF_FLOOR=0.02
+//! 7. Composed: sources=[0.9,0.7]→ds=0.97; CONTRADICTS B(0.5,w=1.0)→0.485;
+//!    SUPERSEDES C(0.6,w=0.8)→≈0.252
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use covalence_engine::confidence::{
+    constants::{CONF_FLOOR, CONTENDS_DEFAULT_WEIGHT, CONTRADICTS_DEFAULT_WEIGHT},
+    recompute_article_confidence,
+};
+
+#[path = "helpers.rs"]
+mod helpers;
+
+// ── helper: get trust_score from db ──────────────────────────────────────────
+
+async fn get_trust_score(pool: &PgPool, article_id: Uuid) -> f64 {
+    sqlx::query_scalar::<_, f64>(
+        "SELECT COALESCE(confidence, 0.5) FROM covalence.nodes WHERE id = $1",
+    )
+    .bind(article_id)
+    .fetch_one(pool)
+    .await
+    .expect("article not found")
+}
+
+async fn get_confidence_breakdown(pool: &PgPool, article_id: Uuid) -> serde_json::Value {
+    sqlx::query_scalar::<_, Option<serde_json::Value>>(
+        "SELECT confidence_breakdown FROM covalence.nodes WHERE id = $1",
+    )
+    .bind(article_id)
+    .fetch_one(pool)
+    .await
+    .expect("article not found")
+    .unwrap_or(serde_json::json!({}))
+}
+
+/// Insert a minimal source node with a given reliability score.
+async fn insert_source_with_reliability(pool: &PgPool, reliability: f64) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, reliability, confidence, namespace) \
+         VALUES ($1, 'source', 'test source', 'content', 'active', $2, $2, 'default')",
+    )
+    .bind(id)
+    .bind(reliability)
+    .execute(pool)
+    .await
+    .expect("insert source");
+    id
+}
+
+/// Insert a minimal article node.
+async fn insert_article(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'article', 'test article', 'content', 'active', 0.5, 'default')",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("insert article");
+    id
+}
+
+/// Link a source to an article in article_sources.
+async fn link_source(
+    pool: &PgPool,
+    article_id: Uuid,
+    source_id: Uuid,
+    relationship: &str,
+    causal_weight: f32,
+    confidence: f32,
+) {
+    sqlx::query(
+        "INSERT INTO covalence.article_sources \
+         (article_id, source_id, relationship, causal_weight, confidence) \
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(article_id)
+    .bind(source_id)
+    .bind(relationship)
+    .bind(causal_weight)
+    .bind(confidence)
+    .execute(pool)
+    .await
+    .expect("link_source");
+}
+
+/// Set the confidence (trust_score) of a node directly.
+async fn set_node_confidence(pool: &PgPool, node_id: Uuid, confidence: f64) {
+    sqlx::query("UPDATE covalence.nodes SET confidence = $1 WHERE id = $2")
+        .bind(confidence)
+        .bind(node_id)
+        .execute(pool)
+        .await
+        .expect("set_node_confidence");
+}
+
+// ── Test 1: Single ORIGINATES source → trust_score == reliability ─────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_single_originates_source() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+    let source_id = insert_source_with_reliability(&pool, 0.75).await;
+    link_source(&pool, article_id, source_id, "originates", 1.0, 1.0).await;
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    assert!(
+        (result.final_score - 0.75).abs() < 1e-6,
+        "expected 0.75, got {}",
+        result.final_score
+    );
+    assert!(
+        result.flags.is_empty(),
+        "unexpected flags: {:?}",
+        result.flags
+    );
+
+    let db_score = get_trust_score(&pool, article_id).await;
+    assert!(
+        (db_score - 0.75).abs() < 1e-6,
+        "DB score mismatch: {db_score}"
+    );
+
+    // contribution_weight should be written back
+    let cw: Option<f32> = sqlx::query_scalar(
+        "SELECT contribution_weight FROM covalence.article_sources \
+         WHERE article_id=$1 AND source_id=$2 AND relationship='originates'",
+    )
+    .bind(article_id)
+    .bind(source_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch contribution_weight");
+    assert!(cw.is_some(), "contribution_weight should be written");
+    assert!(
+        (cw.unwrap() as f64 - 0.75).abs() < 1e-5,
+        "contribution_weight mismatch: {:?}",
+        cw
+    );
+}
+
+// ── Test 2: Three sources → complement-product formula ────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_three_sources_ds_fusion() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+    // effective_rel = source.reliability × 1.0 × 1.0 = reliability
+    for rel in [0.8_f64, 0.7, 0.6] {
+        let sid = insert_source_with_reliability(&pool, rel).await;
+        link_source(&pool, article_id, sid, "originates", 1.0, 1.0).await;
+    }
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    // 1 − (0.2 × 0.3 × 0.4) = 1 − 0.024 = 0.976
+    let expected = 1.0 - (0.2 * 0.3 * 0.4);
+    assert!(
+        (result.final_score - expected).abs() < 1e-6,
+        "expected {expected:.6}, got {:.6}",
+        result.final_score
+    );
+}
+
+// ── Test 3: Zero sources → CONF_FLOOR + "no_sources" flag ─────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_zero_sources_floor_and_flag() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+    // No article_sources rows inserted.
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    assert!(
+        (result.final_score - CONF_FLOOR).abs() < 1e-9,
+        "expected CONF_FLOOR={CONF_FLOOR}, got {}",
+        result.final_score
+    );
+    assert!(
+        result.flags.contains(&"no_sources".to_string()),
+        "expected 'no_sources' flag, got {:?}",
+        result.flags
+    );
+
+    // DB should also show breakdown with flags
+    let bd = get_confidence_breakdown(&pool, article_id).await;
+    let flags = bd["flags"].as_array().expect("flags array");
+    assert!(
+        flags.iter().any(|f| f.as_str() == Some("no_sources")),
+        "breakdown missing 'no_sources' flag"
+    );
+}
+
+// ── Test 4: CONTRADICTS attacker reduces confidence ───────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_contradicts_attacker() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+
+    // Set up DS base of 0.9 via one ORIGINATES source with rel=0.9
+    let orig_src = insert_source_with_reliability(&pool, 0.9).await;
+    link_source(&pool, article_id, orig_src, "originates", 1.0, 1.0).await;
+
+    // Attacker: trust_score=0.8, w=1.0 (CONTRADICTS default)
+    let attacker_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'attacker', 'attack content', 'active', 0.8, 'default')",
+    )
+    .bind(attacker_id)
+    .execute(&pool)
+    .await
+    .expect("insert attacker");
+
+    // causal_weight=1.0 → CONTRADICTS default
+    link_source(&pool, article_id, attacker_id, "contradicts", 1.0, 1.0).await;
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    // conf_ds=0.9; attack=0.8×1.0=0.8; total_attack=0.8; result=0.9×0.2=0.18
+    let expected = 0.9 * (1.0 - 0.8);
+    assert!(
+        (result.final_score - expected).abs() < 1e-6,
+        "expected {expected:.6}, got {:.6}",
+        result.final_score
+    );
+}
+
+// ── Test 5: CONTENDS leaves more confidence than CONTRADICTS ──────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_contends_less_damaging_than_contradicts() {
+    let pool = helpers::setup_pool().await;
+
+    // Article A — has a CONTRADICTS attacker
+    let article_contradicts = insert_article(&pool).await;
+    let orig_c = insert_source_with_reliability(&pool, 0.9).await;
+    link_source(&pool, article_contradicts, orig_c, "originates", 1.0, 1.0).await;
+
+    let attacker_c = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'attacker', 'content', 'active', 0.8, 'default')",
+    )
+    .bind(attacker_c)
+    .execute(&pool)
+    .await
+    .expect("insert");
+    link_source(
+        &pool,
+        article_contradicts,
+        attacker_c,
+        "contradicts",
+        CONTRADICTS_DEFAULT_WEIGHT as f32,
+        1.0,
+    )
+    .await;
+
+    // Article B — same base, same attacker strength, but CONTENDS
+    let article_contends = insert_article(&pool).await;
+    let orig_d = insert_source_with_reliability(&pool, 0.9).await;
+    link_source(&pool, article_contends, orig_d, "originates", 1.0, 1.0).await;
+
+    let attacker_d = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'attacker2', 'content', 'active', 0.8, 'default')",
+    )
+    .bind(attacker_d)
+    .execute(&pool)
+    .await
+    .expect("insert");
+    link_source(
+        &pool,
+        article_contends,
+        attacker_d,
+        "contends",
+        CONTENDS_DEFAULT_WEIGHT as f32,
+        1.0,
+    )
+    .await;
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let r_contradicts = recompute_article_confidence(article_contradicts, &mut conn)
+        .await
+        .expect("recompute contradicts");
+    let r_contends = recompute_article_confidence(article_contends, &mut conn)
+        .await
+        .expect("recompute contends");
+
+    assert!(
+        r_contends.final_score > r_contradicts.final_score,
+        "CONTENDS ({}) should leave more confidence than CONTRADICTS ({})",
+        r_contends.final_score,
+        r_contradicts.final_score
+    );
+}
+
+// ── Test 6: Full supersession → clamped to CONF_FLOOR ────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_full_supersession_clamped_to_floor() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+    let orig_src = insert_source_with_reliability(&pool, 0.9).await;
+    link_source(&pool, article_id, orig_src, "originates", 1.0, 1.0).await;
+
+    // Superseder with trust_score=1.0, causal_weight=1.0 → total_supersede=1.0
+    let superseder_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'superseder', 'new content', 'active', 1.0, 'default')",
+    )
+    .bind(superseder_id)
+    .execute(&pool)
+    .await
+    .expect("insert superseder");
+    // causal_weight=1.0 → supersede_factor=1.0×1.0=1.0
+    link_source(&pool, article_id, superseder_id, "supersedes", 1.0, 1.0).await;
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    assert!(
+        (result.final_score - CONF_FLOOR).abs() < 1e-9,
+        "expected CONF_FLOOR={CONF_FLOOR}, got {}",
+        result.final_score
+    );
+    assert!(
+        result.flags.contains(&"floor_clamped".to_string()),
+        "expected 'floor_clamped' flag, got {:?}",
+        result.flags
+    );
+}
+
+// ── Test 7: Full composed pipeline ───────────────────────────────────────
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_composed_pipeline() {
+    let pool = helpers::setup_pool().await;
+
+    let article_id = insert_article(&pool).await;
+
+    // ORIGINATES sources: reliabilities 0.9 and 0.7
+    // DS: 1 − (0.1 × 0.3) = 1 − 0.03 = 0.97
+    for rel in [0.9_f64, 0.7] {
+        let sid = insert_source_with_reliability(&pool, rel).await;
+        link_source(&pool, article_id, sid, "originates", 1.0, 1.0).await;
+    }
+
+    // CONTRADICTS: B with trust=0.5, w=1.0
+    // total_attack=0.5; conf after penalty=0.97×0.5=0.485
+    let contradicts_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'contradicts_b', 'content', 'active', 0.5, 'default')",
+    )
+    .bind(contradicts_id)
+    .execute(&pool)
+    .await
+    .expect("insert");
+    link_source(
+        &pool,
+        article_id,
+        contradicts_id,
+        "contradicts",
+        1.0, // w=1.0
+        1.0,
+    )
+    .await;
+
+    // SUPERSEDES: C with trust=0.6, causal_weight=0.8
+    // supersede_factor=0.6×0.8=0.48; total_supersede=0.48
+    // conf after decay=0.485×(1−0.48)=0.485×0.52=0.2522
+    let supersedes_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO covalence.nodes \
+         (id, node_type, title, content, status, confidence, namespace) \
+         VALUES ($1, 'source', 'supersedes_c', 'content', 'active', 0.6, 'default')",
+    )
+    .bind(supersedes_id)
+    .execute(&pool)
+    .await
+    .expect("insert");
+    link_source(
+        &pool,
+        article_id,
+        supersedes_id,
+        "supersedes",
+        0.8, // w=0.8
+        1.0,
+    )
+    .await;
+
+    let mut conn = pool.acquire().await.expect("acquire conn");
+    let result = recompute_article_confidence(article_id, &mut conn)
+        .await
+        .expect("recompute");
+
+    // Expected: 0.485 × 0.52 = 0.2522
+    let conf_ds = 0.97_f64;
+    let conf_after_attack = conf_ds * 0.5;
+    let conf_after_decay = conf_after_attack * (1.0 - 0.48);
+    let expected = conf_after_decay.max(CONF_FLOOR);
+
+    assert!(
+        (result.final_score - expected).abs() < 1e-4,
+        "expected {expected:.6}, got {:.6}",
+        result.final_score
+    );
+
+    // Verify breakdown JSON is populated correctly
+    let bd = get_confidence_breakdown(&pool, article_id).await;
+    assert_eq!(bd["ds_fusion"]["source_count"], 2);
+    assert!((bd["ds_fusion"]["raw_score"].as_f64().unwrap() - conf_ds).abs() < 1e-4);
+    assert_eq!(bd["contradicts_penalty"]["attacker_count"], 1);
+    assert_eq!(bd["supersedes_decay"]["superseder_count"], 1);
+}

--- a/engine/tests/integration/test_confidence_propagation.rs
+++ b/engine/tests/integration/test_confidence_propagation.rs
@@ -15,7 +15,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use covalence_engine::confidence::{
-    constants::{CONF_FLOOR, CONTENDS_DEFAULT_WEIGHT, CONTRADICTS_DEFAULT_WEIGHT},
+    constants::{CONF_FLOOR, TEST_CONTENDS_DEFAULT_WEIGHT, TEST_CONTRADICTS_DEFAULT_WEIGHT},
     recompute_article_confidence,
 };
 
@@ -294,7 +294,7 @@ async fn test_contends_less_damaging_than_contradicts() {
         article_contradicts,
         attacker_c,
         "contradicts",
-        CONTRADICTS_DEFAULT_WEIGHT as f32,
+        TEST_CONTRADICTS_DEFAULT_WEIGHT as f32,
         1.0,
     )
     .await;
@@ -319,7 +319,7 @@ async fn test_contends_less_damaging_than_contradicts() {
         article_contends,
         attacker_d,
         "contends",
-        CONTENDS_DEFAULT_WEIGHT as f32,
+        TEST_CONTENDS_DEFAULT_WEIGHT as f32,
         1.0,
     )
     .await;

--- a/engine/tests/test_db_schema.sql
+++ b/engine/tests/test_db_schema.sql
@@ -896,11 +896,13 @@ CREATE TABLE IF NOT EXISTS covalence.article_sources (
 
 CREATE INDEX IF NOT EXISTS idx_article_sources_article_relationship
     ON covalence.article_sources (article_id, relationship)
-    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes');
+    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes')
+      AND superseded_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_article_sources_source_relationship
     ON covalence.article_sources (source_id, relationship)
-    WHERE relationship IN ('supersedes', 'contradicts', 'contends');
+    WHERE relationship IN ('supersedes', 'contradicts', 'contends')
+      AND superseded_at IS NULL;
 
 -- confidence_breakdown column on articles (stored in nodes).
 ALTER TABLE covalence.nodes

--- a/engine/tests/test_db_schema.sql
+++ b/engine/tests/test_db_schema.sql
@@ -860,3 +860,48 @@ BEGIN
     RETURNING *;
 END;
 $$;
+
+-- =============================================================================
+-- Migration 037: Confidence Propagation Phase 1 (covalence#137)
+-- =============================================================================
+
+-- article_sources: provenance bridge for DS-fusion pipeline.
+CREATE TABLE IF NOT EXISTS covalence.article_sources (
+    article_id           UUID          NOT NULL
+                           REFERENCES covalence.nodes(id) ON DELETE CASCADE,
+    source_id            UUID          NOT NULL
+                           REFERENCES covalence.nodes(id) ON DELETE CASCADE,
+    relationship         TEXT          NOT NULL
+                           CONSTRAINT article_sources_relationship_check
+                           CHECK (relationship IN (
+                               'originates', 'compiled_from',
+                               'confirms', 'supersedes',
+                               'contradicts', 'contends'
+                           )),
+    causal_weight        REAL          NOT NULL DEFAULT 1.0
+                           CONSTRAINT article_sources_causal_weight_range
+                           CHECK (causal_weight >= 0.0 AND causal_weight <= 1.0),
+    confidence           REAL          NOT NULL DEFAULT 1.0
+                           CONSTRAINT article_sources_confidence_range
+                           CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    contribution_weight  REAL
+                           CONSTRAINT article_sources_contribution_weight_range
+                           CHECK (contribution_weight IS NULL
+                                  OR (contribution_weight >= 0.0
+                                      AND contribution_weight <= 1.0)),
+    superseded_at        TIMESTAMPTZ,
+    added_at             TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (article_id, source_id, relationship)
+);
+
+CREATE INDEX IF NOT EXISTS idx_article_sources_article_relationship
+    ON covalence.article_sources (article_id, relationship)
+    WHERE relationship IN ('originates', 'contradicts', 'contends', 'supersedes');
+
+CREATE INDEX IF NOT EXISTS idx_article_sources_source_relationship
+    ON covalence.article_sources (source_id, relationship)
+    WHERE relationship IN ('supersedes', 'contradicts', 'contends');
+
+-- confidence_breakdown column on articles (stored in nodes).
+ALTER TABLE covalence.nodes
+    ADD COLUMN IF NOT EXISTS confidence_breakdown JSONB;


### PR DESCRIPTION
## Summary

Implements Phase 1 confidence propagation for Covalence KB nodes.

### What's New

**Migration 037** (`engine/migrations/037_confidence_propagation.sql`):
- Creates `covalence.article_sources` — provenance bridge table with `article_id`, `source_id`, `relationship`, `causal_weight`, `confidence`, `contribution_weight` (nullable), `superseded_at` (reserved Phase 2), `added_at`
- Adds `covalence.nodes.confidence_breakdown` (JSONB nullable)
- Two partial indexes for efficient query patterns
- `superseded_at IS NULL` filter applied from day 1 (Phase 2 ready)

**`src/confidence/` module** (6 files):
- `constants.rs` — `CONF_FLOOR=0.02`, contradiction/contention default weights
- `ds_fusion.rs` — complement-product formula: `1 − ∏(1 − rᵢ)`
- `dfquad_penalty.rs` — DF-QuAD: `conf × (1 − ∏(1 − trust×w))`
- `supersedes_decay.rs` — same formula applied as supersession decay
- `recompute.rs` — three-phase pipeline (DS fusion → DF-QuAD penalty → SUPERSEDES decay)
- `mod.rs` — `ConfidenceResult` struct + re-exports

### Test Results

| Suite | Result |
|-------|--------|
| Unit (`cargo test --lib`) | 84 pass ✅ |
| Integration | 222 pass (+7 new), 4 pre-existing fails (notes column) ✅ |
| New confidence tests | **7/7 pass** ✅ |

### Implementation Notes

- `article_sources` created fresh (didn't exist in migrations 001–036); `IF NOT EXISTS` guard ensures idempotency
- REAL→f64 narrowing fix in `recompute.rs` (explicit `f32` extraction before widening)
- Module declared in both `lib.rs` and `main.rs` (split lib+bin topology)

Closes #137