### PR TITLE
chore(worker): extract source-ranking helpers, post-compile tasks, node_type-aware consolidation (#173 wave 3)

### DIFF
--- a/engine/src/worker/consolidation.rs
+++ b/engine/src/worker/consolidation.rs
@@ -175,36 +175,6 @@ pub fn next_pass_delay(completed_pass: i32) -> chrono::Duration {
     }
 }
 
-/// Select up to `cap` source IDs from `candidate_ids`, ranked by
-/// `trust_score × exp(-0.1 × days_old)` (covalence#104 recency formula).
-///
-/// `reliability` is used as the trust_score proxy (same column as the
-/// covalence#85 source cap).  Days are computed from `created_at`.
-async fn select_by_trust_recency(
-    pool: &PgPool,
-    candidate_ids: &[Uuid],
-    cap: usize,
-) -> anyhow::Result<Vec<Uuid>> {
-    if candidate_ids.is_empty() {
-        return Ok(vec![]);
-    }
-    sqlx::query_scalar(
-        "SELECT id
-         FROM   covalence.nodes
-         WHERE  id = ANY($1)
-         ORDER BY
-             COALESCE(reliability, 0.5)
-             * EXP(-0.1 * EXTRACT(EPOCH FROM (now() - COALESCE(created_at, now()))) / 86400.0)
-             DESC
-         LIMIT $2",
-    )
-    .bind(candidate_ids)
-    .bind(cap as i64)
-    .fetch_all(pool)
-    .await
-    .context("select_by_trust_recency: failed to rank sources")
-}
-
 /// Mark sources that fell outside the distillation cap with
 /// `metadata.distilled_out_at = <now>` (non-destructive; edges are kept).
 async fn mark_distilled_out(pool: &PgPool, source_ids: &[Uuid]) -> anyhow::Result<()> {
@@ -440,7 +410,9 @@ pub async fn handle_consolidate_article(
 
         if let Some(cap) = stage.source_cap() {
             // Stages 2–4: trust_score × recency ranking + distilled_out marking.
-            let selected = select_by_trust_recency(pool, &all_source_ids, cap).await?;
+            let selected =
+                super::source_selection::select_by_trust_recency(pool, &all_source_ids, cap)
+                    .await?;
 
             let selected_set: std::collections::HashSet<Uuid> = selected.iter().copied().collect();
             let dropped: Vec<Uuid> = all_source_ids
@@ -467,15 +439,11 @@ pub async fn handle_consolidate_article(
             // Stage 1: legacy reliability-ranked cap (covalence#85).
             const MAX_COMPILATION_SOURCES: usize = 7;
             if original_source_count > MAX_COMPILATION_SOURCES {
-                let capped: Vec<Uuid> = sqlx::query_scalar(
-                    "SELECT id FROM covalence.nodes \
-                     WHERE  id = ANY($1) \
-                     ORDER BY COALESCE(reliability, 0.5) DESC \
-                     LIMIT  $2",
+                let capped = super::source_selection::select_by_reliability(
+                    pool,
+                    &all_source_ids,
+                    MAX_COMPILATION_SOURCES,
                 )
-                .bind(&all_source_ids)
-                .bind(MAX_COMPILATION_SOURCES as i64)
-                .fetch_all(pool)
                 .await
                 .context("consolidate_article: failed to score sources for cap")?;
                 tracing::info!(

--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -25,6 +25,7 @@ pub mod navigation;
 pub mod openai;
 pub mod provenance_cap;
 pub mod reconsolidation;
+pub mod source_selection;
 pub mod tree_index;
 
 use std::sync::Arc;
@@ -135,7 +136,7 @@ pub async fn run_with_token(pool: PgPool, llm: Arc<dyn LlmClient>, token: Cancel
 
         // Periodically enqueue consolidation tasks for due articles.
         if heartbeat_tick % CONSOLIDATION_HEARTBEAT_INTERVAL == 0 {
-            if let Err(e) = enqueue_due_consolidations(&pool).await {
+            if let Err(e) = enqueue_due_article_consolidations(&pool).await {
                 tracing::error!("consolidation heartbeat error: {e:#}");
             }
         }
@@ -359,10 +360,14 @@ async fn execute_and_finalize(pool: PgPool, llm: Arc<dyn LlmClient>, task: Queue
     }
 }
 
-/// Enqueue `consolidate_article` tasks for every active article whose
+/// Enqueue `consolidate_article` tasks for every active **article** node whose
 /// `next_consolidation_at` has arrived and that has no pending/processing
 /// consolidation task already.
-async fn enqueue_due_consolidations(pool: &PgPool) -> anyhow::Result<()> {
+///
+/// The query explicitly filters `node_type = 'article'` so that future
+/// `node_type = 'claim'` nodes are never swept into this heartbeat by accident
+/// (covalence#173).
+async fn enqueue_due_article_consolidations(pool: &PgPool) -> anyhow::Result<()> {
     use sqlx::Row as _;
 
     let rows = sqlx::query(
@@ -982,17 +987,10 @@ pub async fn handle_compile(
     const MAX_COMPILATION_SOURCES: usize = 7;
     let original_source_count = source_ids.len();
     let source_ids = if original_source_count > MAX_COMPILATION_SOURCES {
-        let capped: Vec<Uuid> = sqlx::query_scalar(
-            "SELECT id FROM covalence.nodes \
-             WHERE  id = ANY($1) \
-             ORDER BY COALESCE(reliability, 0.5) DESC \
-             LIMIT  $2",
-        )
-        .bind(&source_ids)
-        .bind(MAX_COMPILATION_SOURCES as i64)
-        .fetch_all(pool)
-        .await
-        .context("compile: failed to score sources for cap")?;
+        let capped =
+            source_selection::select_by_reliability(pool, &source_ids, MAX_COMPILATION_SOURCES)
+                .await
+                .context("compile: failed to score sources for cap")?;
         tracing::info!(
             task_id   = %task.id,
             original  = original_source_count,
@@ -1486,14 +1484,64 @@ SOURCE DOCUMENTS:\n\
     }
 
     // ── 8. Queue follow-up tasks ────────────────────────────────────────────
+    let source_ids_for_tasks: Vec<Uuid> = sources.iter().map(|s| s.id).collect();
+    schedule_post_article_compile_tasks(
+        pool,
+        article_id,
+        &source_ids_for_tasks,
+        article_content.len(),
+    )
+    .await?;
+
+    tracing::info!(
+        article_id  = %article_id,
+        title       = %article_title,
+        content_len = article_content.len(),
+        degraded,
+        "compile: done"
+    );
+
+    Ok(json!({
+        "article_id":     article_id,
+        "title":          article_title,
+        "content_len":    article_content.len(),
+        "epistemic_type": epistemic_type,
+        "degraded":       degraded,
+        "source_count":   sources.len(),
+    }))
+}
+
+/// Enqueue the standard set of follow-up tasks after an article node has been
+/// compiled or updated by [`handle_compile`].
+///
+/// Extracted from the inline block at the end of `handle_compile` so that the
+/// claims compilation handler (covalence#173) can use a *different* post-task
+/// sequence without accidentally inheriting this one.  Naming it
+/// `_article_compile_tasks` makes the scope explicit.
+///
+/// Tasks queued (in order):
+/// 1. `embed` — generate/refresh the article's vector embedding.
+/// 2. `contention_check` — check each source for contradictions.
+/// 3. `split` — only when `content_len > 14 000` chars (structural split).
+/// 4. `critique_article` — deferred 1 h (Reflexion loop, covalence#105).
+/// 5. `infer_article_edges` — article-to-article semantic edges (covalence#160).
+/// 6. `auto_split` — provenance-overflow guard (covalence#161), enqueued only
+///    when the ORIGINATES edge count exceeds the configured threshold and no
+///    such task is already pending/processing.
+async fn schedule_post_article_compile_tasks(
+    pool: &PgPool,
+    article_id: Uuid,
+    source_ids: &[Uuid],
+    content_len: usize,
+) -> anyhow::Result<()> {
     enqueue_task(pool, "embed", Some(article_id), json!({}), 5).await?;
-    for src in &sources {
-        enqueue_task(pool, "contention_check", Some(src.id), json!({}), 3).await?;
+    for &src_id in source_ids {
+        enqueue_task(pool, "contention_check", Some(src_id), json!({}), 3).await?;
     }
-    if article_content.len() > 14_000 {
+    if content_len > 14_000 {
         tracing::info!(
             article_id  = %article_id,
-            content_len = article_content.len(),
+            content_len,
             "compile: content large, queuing split task"
         );
         enqueue_task(pool, "split", Some(article_id), json!({}), 4).await?;
@@ -1518,10 +1566,10 @@ SOURCE DOCUMENTS:\n\
     // available quickly but lower than embed (5) so embedding lands first.
     enqueue_task(pool, "infer_article_edges", Some(article_id), json!({}), 3).await?;
 
-    // ── Auto-split trigger (covalence#161) ──────────────────────────────────
-    // Count ORIGINATES edges accumulated on this article across all compile
-    // calls.  If the count exceeds PROVENANCE_SPLIT_THRESHOLD, enqueue an
-    // auto_split task (idempotent: skips if one is already pending/running).
+    // Auto-split trigger (covalence#161): count ORIGINATES edges accumulated
+    // on this article across all compile calls.  If the count exceeds
+    // PROVENANCE_SPLIT_THRESHOLD, enqueue an auto_split task (idempotent:
+    // skips if one is already pending/running).
     {
         let split_threshold = provenance_cap::provenance_split_threshold() as i64;
         let originates_count: i64 = sqlx::query_scalar(
@@ -1577,22 +1625,7 @@ SOURCE DOCUMENTS:\n\
         }
     }
 
-    tracing::info!(
-        article_id  = %article_id,
-        title       = %article_title,
-        content_len = article_content.len(),
-        degraded,
-        "compile: done"
-    );
-
-    Ok(json!({
-        "article_id":     article_id,
-        "title":          article_title,
-        "content_len":    article_content.len(),
-        "epistemic_type": epistemic_type,
-        "degraded":       degraded,
-        "source_count":   sources.len(),
-    }))
+    Ok(())
 }
 
 /// `split`: Split an oversized article node into two smaller nodes.

--- a/engine/src/worker/source_selection.rs
+++ b/engine/src/worker/source_selection.rs
@@ -1,0 +1,67 @@
+//! Source-ranking helpers shared across worker task handlers.
+//!
+//! These pure-DB query functions rank candidate source nodes by different
+//! criteria and are shared by `compile`, `consolidate_article`, and (in future)
+//! claims compilation.  Extracting them here prevents a third inline copy when
+//! the claims worker needs the same logic (covalence#173 wave 3).
+
+use anyhow::Context;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Select up to `cap` source IDs from `candidate_ids`, ranked by
+/// `trust_score × exp(-0.1 × days_old)` (covalence#104 recency formula).
+///
+/// `reliability` is used as the trust_score proxy.  Days are computed from
+/// `created_at`.  Returns an empty [`Vec`] immediately when `candidate_ids` is
+/// empty (no DB round-trip).
+pub(crate) async fn select_by_trust_recency(
+    pool: &PgPool,
+    candidate_ids: &[Uuid],
+    cap: usize,
+) -> anyhow::Result<Vec<Uuid>> {
+    if candidate_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    sqlx::query_scalar(
+        "SELECT id
+         FROM   covalence.nodes
+         WHERE  id = ANY($1)
+         ORDER BY
+             COALESCE(reliability, 0.5)
+             * EXP(-0.1 * EXTRACT(EPOCH FROM (now() - COALESCE(created_at, now()))) / 86400.0)
+             DESC
+         LIMIT $2",
+    )
+    .bind(candidate_ids)
+    .bind(cap as i64)
+    .fetch_all(pool)
+    .await
+    .context("select_by_trust_recency: failed to rank sources")
+}
+
+/// Select up to `cap` source IDs from `candidate_ids`, ranked by `reliability`
+/// only (descending).
+///
+/// Used for the Stage 1 "lost-in-the-middle" source cap (covalence#85).
+/// Returns an empty [`Vec`] immediately when `candidate_ids` is empty.
+pub(crate) async fn select_by_reliability(
+    pool: &PgPool,
+    candidate_ids: &[Uuid],
+    cap: usize,
+) -> anyhow::Result<Vec<Uuid>> {
+    if candidate_ids.is_empty() {
+        return Ok(vec![]);
+    }
+    sqlx::query_scalar(
+        "SELECT id FROM covalence.nodes \
+         WHERE  id = ANY($1) \
+         ORDER BY COALESCE(reliability, 0.5) DESC \
+         LIMIT  $2",
+    )
+    .bind(candidate_ids)
+    .bind(cap as i64)
+    .fetch_all(pool)
+    .await
+    .context("select_by_reliability: failed to rank sources")
+}


### PR DESCRIPTION
## Summary

Structural refactor — no behaviour changes. Three surgical extractions to prepare the worker for the incoming claims worker (covalence#173).

---

### Change 1.2 — Shared source-ranking helpers ()

**New file:** `engine/src/worker/source_selection.rs`

- Extracted the private `select_by_trust_recency` from `consolidation.rs` into a `pub(crate)` function in the new shared module.
- Added `pub(crate) select_by_reliability` — same shape, ranks by `reliability` only (the Stage 1 / `MAX_COMPILATION_SOURCES = 7` path). Previously duplicated as an inline `sqlx::query_scalar` block in both `handle_compile` (mod.rs) and the Stage-1 branch of `handle_consolidate_article` (consolidation.rs).
- Updated all three callsites to use the shared helpers.

**Why:** the claims worker will need source ranking; without shared helpers it would write a third copy.

---

### Change 1.3 — Extracted post-compile task sequence

**File:** `engine/src/worker/mod.rs`

- The ~50-line inline "Queue follow-up tasks" block at the end of `handle_compile` is now `async fn schedule_post_article_compile_tasks(pool, article_id, source_ids, content_len)`.
- Tasks enqueued (identical to before): `embed`, `contention_check` (per source), conditional `split`, deferred `critique_article`, `infer_article_edges`, conditional `auto_split`.
- One callsite in `handle_compile` replaced with the function call.

**Why:** claims compilation will have a different post-task sequence. Naming the article version makes the scope explicit and prevents accidental inheritance.

---

### Change 1.4 — node_type-aware consolidation heartbeat

**File:** `engine/src/worker/mod.rs`

- Renamed `enqueue_due_consolidations` → `enqueue_due_article_consolidations`.
- The query already filtered `node_type = 'article'`; the rename makes that scope visible at the callsite.
- Updated the single callsite in the heartbeat tick handler.

**Why:** during the blue-green period, `node_type = 'claim'` nodes must not be swept into the article consolidation heartbeat.

---

## Files touched

| File | Change |
|------|--------|
| `engine/src/worker/source_selection.rs` | **New** — shared source-ranking helpers |
| `engine/src/worker/mod.rs` | Extract `select_by_reliability` callsite, extract `schedule_post_article_compile_tasks`, rename heartbeat fn |
| `engine/src/worker/consolidation.rs` | Remove private `select_by_trust_recency`, update two callsites to use shared module |

## Verification

- `cargo fmt` — clean
- `cargo check` — 0 errors (pre-existing warnings only)
- `cargo test` — 236 pass, 4 pre-existing failures in `test_causal_metadata` (missing `notes` column in test-DB schema, also failing on `main`)