### PR TITLE
chore(edge-service,services): symmetric-edge generalization + node-creation helpers (#173 wave 5)

### DIFF
--- a/engine/src/models/mod.rs
+++ b/engine/src/models/mod.rs
@@ -198,6 +198,16 @@ impl EdgeType {
         )
     }
 
+    /// Returns `true` when an edge of this type requires an automatic inverse
+    /// to enforce symmetry (covalence#173 wave 5).
+    ///
+    /// Symmetric edge types:
+    /// * [`EdgeType::Contradicts`] — Dung (1995) attack relation must be symmetric.
+    /// * [`EdgeType::ContradictsClaim`] — claim-level contradiction is likewise symmetric.
+    pub fn is_symmetric(&self) -> bool {
+        matches!(self, EdgeType::Contradicts | EdgeType::ContradictsClaim)
+    }
+
     /// Claim edges — introduced by the claims pipeline (#169).
     #[allow(dead_code)]
     pub fn is_claim_edge(&self) -> bool {

--- a/engine/src/services/article_service.rs
+++ b/engine/src/services/article_service.rs
@@ -9,6 +9,7 @@ use crate::errors::*;
 use crate::graph::{GraphRepository, SqlGraphRepository};
 use crate::models::article_state::{Active, Archived, TypedArticle};
 use crate::models::*;
+use crate::services::node_helpers;
 
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
 pub struct CreateArticleRequest {
@@ -139,8 +140,8 @@ impl ArticleService {
     pub async fn create(&self, req: CreateArticleRequest) -> AppResult<ArticleResponse> {
         let id = Uuid::new_v4();
         let now = Utc::now();
-        let content_hash = hex::encode(Sha256::digest(req.content.as_bytes()));
-        let size_tokens = (req.content.split_whitespace().count() as f64 / 0.75) as i32;
+        let content_hash = node_helpers::compute_content_hash(&req.content);
+        let size_tokens = node_helpers::estimate_size_tokens(&req.content);
         let domain_path = req.domain_path.unwrap_or_default();
         let epistemic_type = req.epistemic_type.unwrap_or_else(|| "semantic".into());
         let metadata = req.metadata.unwrap_or(serde_json::json!({}));
@@ -203,21 +204,13 @@ impl ArticleService {
         }
 
         // Queue embedding with contextual preamble (covalence#73).
-        let preamble = format!(
-            "[Context: {}. Source type: article. Domain: {}.]",
-            req.title.as_deref().unwrap_or(""),
-            domain_path.join("/"),
-        );
-        let embed_payload = serde_json::json!({ "embed_preamble": preamble });
-        sqlx::query(
-            "INSERT INTO covalence.slow_path_queue \
-             (id, task_type, node_id, payload, priority, status) \
-             VALUES ($1, 'embed', $2, $3, 3, 'pending')",
+        node_helpers::enqueue_embed_with_preamble(
+            &self.pool,
+            id,
+            req.title.as_deref(),
+            "article",
+            &domain_path,
         )
-        .bind(Uuid::new_v4())
-        .bind(id)
-        .bind(&embed_payload)
-        .execute(&self.pool)
         .await?;
 
         self.get(id).await
@@ -796,26 +789,25 @@ impl ArticleService {
 }
 
 fn article_from_row(row: &PgRow) -> ArticleResponse {
+    let core = node_helpers::node_core_from_row(row);
     ArticleResponse {
-        id: row.get("id"),
+        id: core.id,
         node_type: "article".into(),
-        title: row.get("title"),
-        content: row.get("content"),
+        title: core.title,
+        content: core.content,
         stale: None,
-        status: row.get("status"),
-        confidence: row.get::<Option<f64>, _>("confidence").unwrap_or(0.5) as f32,
-        epistemic_type: row.get("epistemic_type"),
-        domain_path: row
-            .get::<Option<Vec<String>>, _>("domain_path")
-            .unwrap_or_default(),
-        metadata: row.get::<serde_json::Value, _>("metadata"),
-        version: row.get::<Option<i32>, _>("version").unwrap_or(1),
-        pinned: row.get::<Option<bool>, _>("pinned").unwrap_or(false),
-        usage_score: row.get::<Option<f64>, _>("usage_score").unwrap_or(0.0) as f32,
+        status: core.status,
+        confidence: core.confidence,
+        epistemic_type: core.epistemic_type,
+        domain_path: core.domain_path,
+        metadata: core.metadata,
+        version: core.version,
+        pinned: core.pinned,
+        usage_score: core.usage_score,
         contention_count: row.get::<Option<i64>, _>("contention_count").unwrap_or(0),
-        content_hash: row.get("content_hash"),
-        created_at: row.get("created_at"),
-        modified_at: row.get("modified_at"),
+        content_hash: core.content_hash,
+        created_at: core.created_at,
+        modified_at: core.modified_at,
         facet_function: row.get("facet_function"),
         facet_scope: row.get("facet_scope"),
     }

--- a/engine/src/services/edge_service.rs
+++ b/engine/src/services/edge_service.rs
@@ -1,6 +1,6 @@
 //! Edge operations — create, delete, list, neighborhood traversal.
 
-use sqlx::PgPool;
+use sqlx::{PgPool, Row as _};
 use uuid::Uuid;
 
 use crate::errors::*;
@@ -40,11 +40,12 @@ impl EdgeService {
     /// Create a typed edge between two nodes.
     ///
     /// Enforces inference rules on write:
-    /// * **CONTRADICTS symmetry** (covalence#99): when A CONTRADICTS B is written,
-    ///   the inverse B CONTRADICTS A is automatically created if it does not already
-    ///   exist.  Both the primary insert and the inverse insert use
-    ///   `ON CONFLICT … DO NOTHING` so that the operation is idempotent: writing
-    ///   an edge that already exists returns the existing edge rather than an error.
+    /// * **Symmetric-edge enforcement** (covalence#99, covalence#173): when an
+    ///   edge whose [`EdgeType::is_symmetric`] returns `true` (e.g. CONTRADICTS,
+    ///   CONTRADICTS_CLAIM) is written, the inverse edge is automatically created
+    ///   if it does not already exist.  Both directions use
+    ///   `ON CONFLICT … DO NOTHING` so the operation is idempotent: writing an
+    ///   edge that already exists returns the existing edge rather than an error.
     pub async fn create(&self, req: CreateEdgeRequest) -> AppResult<Edge> {
         let edge_type: EdgeType = req
             .label
@@ -55,20 +56,18 @@ impl EdgeService {
         let confidence = req.confidence.unwrap_or(1.0);
         let props = serde_json::json!({"notes": req.notes});
 
-        // ── Primary edge insert ───────────────────────────────────────────────
-        // For CONTRADICTS edges we use an upsert helper so that symmetry
-        // enforcement (which may have already created this direction) does not
-        // produce a unique-constraint error.  All other edge types go through
-        // the standard repository path.
-        let edge = if edge_type == EdgeType::Contradicts {
-            self.upsert_contradicts_edge(
+        if edge_type.is_symmetric() {
+            // Symmetric types get an idempotent upsert for the primary direction
+            // plus an automatic inverse.
+            self.ensure_symmetric_edge(
                 req.from_node_id,
                 req.to_node_id,
+                edge_type,
                 confidence,
                 method,
                 &props,
             )
-            .await?
+            .await
         } else {
             self.graph
                 .create_edge(
@@ -80,95 +79,76 @@ impl EdgeService {
                     props,
                 )
                 .await
-                .map_err(AppError::Graph)?
-        };
-
-        // ── Inference rule: CONTRADICTS symmetry ─────────────────────────────
-        // Dung (1995): the "attack" relation must be symmetric.  When A→B
-        // CONTRADICTS is written, auto-create B→A CONTRADICTS if absent.
-        if edge_type == EdgeType::Contradicts {
-            sqlx::query(
-                "INSERT INTO covalence.edges \
-                 (id, source_node_id, target_node_id, edge_type, \
-                  weight, confidence, causal_weight, metadata, created_by, valid_from) \
-                 VALUES (gen_random_uuid(), $1, $2, 'CONTRADICTS', $3, $4, $5, $6, $7, now()) \
-                 ON CONFLICT (source_node_id, target_node_id, edge_type) DO NOTHING",
-            )
-            .bind(req.to_node_id) // B → becomes source of inverse
-            .bind(req.from_node_id) // A → becomes target of inverse
-            .bind(edge.weight)
-            .bind(edge.confidence)
-            .bind(edge.causal_weight) // CONTRADICTS causal_weight = 0.50
-            .bind(serde_json::json!({
-                "inferred_by":    "contradicts_symmetry",
-                "source_edge_id": edge.id.to_string(),
-            }))
-            .bind("kg_inference")
-            .execute(&self.pool)
-            .await
-            .map_err(AppError::Database)?;
+                .map_err(AppError::Graph)
         }
-
-        Ok(edge)
     }
 
-    /// Insert a CONTRADICTS edge if it does not already exist, or return the
-    /// existing active edge.  Uses `ON CONFLICT … DO NOTHING` followed by a
-    /// SELECT so the operation is idempotent regardless of which side of a
-    /// symmetric pair is written first.
-    async fn upsert_contradicts_edge(
+    /// Insert a symmetric edge pair and return the primary (from→to) edge.
+    ///
+    /// Both the primary insert and the inverse insert use
+    /// `ON CONFLICT … DO NOTHING` so the helper is idempotent: calling it when
+    /// either direction already exists is a no-op for that direction.
+    ///
+    /// This generalises the former `upsert_contradicts_edge` / raw-inverse-INSERT
+    /// pair so that any [`EdgeType::is_symmetric`] type gets the same treatment
+    /// without duplication (covalence#173 wave 5 change 2.2).
+    async fn ensure_symmetric_edge(
         &self,
         from_id: Uuid,
         to_id: Uuid,
+        edge_type: EdgeType,
         confidence: f32,
         created_by: &str,
         props: &serde_json::Value,
     ) -> AppResult<Edge> {
-        // causal_weight for CONTRADICTS is always 0.50.
-        let causal_weight = EdgeType::Contradicts.causal_weight();
+        let label = edge_type.as_label();
+        let causal_weight = edge_type.causal_weight();
 
-        // Attempt insert; silently skip if the edge already exists.
-        sqlx::query(
+        // ── Primary direction ─────────────────────────────────────────────────
+        // Attempt insert; silently skip if the edge already exists (e.g. the
+        // inverse was written first and already created this direction).
+        let insert_sql = format!(
             "INSERT INTO covalence.edges \
              (id, source_node_id, target_node_id, edge_type, \
               weight, confidence, causal_weight, metadata, created_by, valid_from) \
-             VALUES (gen_random_uuid(), $1, $2, 'CONTRADICTS', 1.0, $3, $4, $5, $6, now()) \
+             VALUES (gen_random_uuid(), $1, $2, '{label}', 1.0, $3, $4, $5, $6, now()) \
              ON CONFLICT (source_node_id, target_node_id, edge_type) DO NOTHING",
-        )
-        .bind(from_id)
-        .bind(to_id)
-        .bind(confidence)
-        .bind(causal_weight)
-        .bind(props)
-        .bind(created_by)
-        .execute(&self.pool)
-        .await
-        .map_err(AppError::Database)?;
+        );
+        sqlx::query(&insert_sql)
+            .bind(from_id)
+            .bind(to_id)
+            .bind(confidence)
+            .bind(causal_weight)
+            .bind(props)
+            .bind(created_by)
+            .execute(&self.pool)
+            .await
+            .map_err(AppError::Database)?;
 
         // Fetch the canonical row (inserted or pre-existing).
-        let row = sqlx::query(
+        let select_sql = format!(
             "SELECT id, age_id, source_node_id, target_node_id, edge_type, \
                     weight, confidence, causal_weight, metadata, created_at, created_by, \
                     valid_from, valid_to \
              FROM covalence.edges \
              WHERE source_node_id = $1 AND target_node_id = $2 \
-               AND edge_type = 'CONTRADICTS' \
+               AND edge_type = '{label}' \
                AND valid_to IS NULL \
              LIMIT 1",
-        )
-        .bind(from_id)
-        .bind(to_id)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(AppError::Database)?;
+        );
+        let row = sqlx::query(&select_sql)
+            .bind(from_id)
+            .bind(to_id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(AppError::Database)?;
 
-        use sqlx::Row as _;
-        Ok(Edge {
+        let edge = Edge {
             id: row.try_get("id").map_err(AppError::Database)?,
             age_id: row.try_get("age_id").map_err(AppError::Database)?,
             source_node_id: row.try_get("source_node_id").map_err(AppError::Database)?,
             target_node_id: row.try_get("target_node_id").map_err(AppError::Database)?,
-            edge_type: EdgeType::Contradicts,
+            edge_type,
             weight: row
                 .try_get::<f64, _>("weight")
                 .map_err(AppError::Database)? as f32,
@@ -183,7 +163,35 @@ impl EdgeService {
             created_by: row.try_get("created_by").map_err(AppError::Database)?,
             valid_from: row.try_get("valid_from").map_err(AppError::Database)?,
             valid_to: row.try_get("valid_to").map_err(AppError::Database)?,
-        })
+        };
+
+        // ── Inverse direction ─────────────────────────────────────────────────
+        // Auto-create the B→A complement so the symmetric invariant is always
+        // maintained.  DO NOTHING makes this idempotent if the inverse was
+        // already written by an earlier call.
+        let inverse_sql = format!(
+            "INSERT INTO covalence.edges \
+             (id, source_node_id, target_node_id, edge_type, \
+              weight, confidence, causal_weight, metadata, created_by, valid_from) \
+             VALUES (gen_random_uuid(), $1, $2, '{label}', $3, $4, $5, $6, $7, now()) \
+             ON CONFLICT (source_node_id, target_node_id, edge_type) DO NOTHING",
+        );
+        sqlx::query(&inverse_sql)
+            .bind(to_id) // B → becomes source of inverse
+            .bind(from_id) // A → becomes target of inverse
+            .bind(edge.weight)
+            .bind(edge.confidence)
+            .bind(edge.causal_weight)
+            .bind(serde_json::json!({
+                "inferred_by":    "symmetric_edge",
+                "source_edge_id": edge.id.to_string(),
+            }))
+            .bind("kg_inference")
+            .execute(&self.pool)
+            .await
+            .map_err(AppError::Database)?;
+
+        Ok(edge)
     }
 
     /// Delete an edge.

--- a/engine/src/services/mod.rs
+++ b/engine/src/services/mod.rs
@@ -5,6 +5,7 @@ pub mod concerns_service;
 pub mod contention_service;
 pub mod edge_service;
 pub mod memory_service;
+pub(crate) mod node_helpers;
 pub mod provenance_trace_service;
 pub mod search_service;
 pub mod session_service;

--- a/engine/src/services/node_helpers.rs
+++ b/engine/src/services/node_helpers.rs
@@ -1,0 +1,133 @@
+//! Shared helpers for node creation — used by article_service and (soon) claim_service.
+//!
+//! Extracted from `article_service.rs` as part of covalence#173 wave 5 (changes 4.2 + 4.3)
+//! so that `ClaimService::create()` can reuse the same SHA-256 hashing, token estimation,
+//! and embed-task enqueueing logic without verbatim duplication.
+
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Row, postgres::PgRow};
+use uuid::Uuid;
+
+use crate::errors::AppError;
+
+// =============================================================================
+// Change 4.2 — node-creation helpers
+// =============================================================================
+
+/// Compute the hex-encoded SHA-256 digest of `content`.
+///
+/// Used for tamper detection and federation trust verification (covalence#78).
+pub(crate) fn compute_content_hash(content: &str) -> String {
+    hex::encode(Sha256::digest(content.as_bytes()))
+}
+
+/// Estimate a token count from raw content using the heuristic word_count / 0.75
+/// (≈ 1.33 words per token, matching GPT-family tokenisation at prose density).
+pub(crate) fn estimate_size_tokens(content: &str) -> i32 {
+    (content.split_whitespace().count() as f64 / 0.75) as i32
+}
+
+/// Queue an embedding task for `node_id` with a contextual preamble (covalence#73).
+///
+/// The preamble is injected into the `embed_preamble` field of the slow-path
+/// queue payload so the embedding worker can prepend it to the content before
+/// vectorising.
+///
+/// # Parameters
+/// * `pool`          — database connection pool
+/// * `node_id`       — UUID of the node to embed
+/// * `title`         — optional node title (used in preamble context string)
+/// * `node_type_str` — human-readable node type (e.g. `"article"`, `"claim"`)
+/// * `domain_path`   — domain tags joined with `/` for the preamble
+pub(crate) async fn enqueue_embed_with_preamble(
+    pool: &PgPool,
+    node_id: Uuid,
+    title: Option<&str>,
+    node_type_str: &str,
+    domain_path: &[String],
+) -> Result<(), AppError> {
+    let preamble = format!(
+        "[Context: {}. Source type: {}. Domain: {}.]",
+        title.unwrap_or(""),
+        node_type_str,
+        domain_path.join("/"),
+    );
+    let embed_payload = serde_json::json!({ "embed_preamble": preamble });
+
+    sqlx::query(
+        "INSERT INTO covalence.slow_path_queue \
+         (id, task_type, node_id, payload, priority, status) \
+         VALUES ($1, 'embed', $2, $3, 3, 'pending')",
+    )
+    .bind(Uuid::new_v4())
+    .bind(node_id)
+    .bind(&embed_payload)
+    .execute(pool)
+    .await
+    .map_err(AppError::Database)?;
+
+    Ok(())
+}
+
+// =============================================================================
+// Change 4.3 — NodeCore + node_core_from_row
+// =============================================================================
+
+/// Common node fields shared by every node type's row-mapping helper.
+///
+/// Captures the 12+ fields that appear in every `SELECT … FROM covalence.nodes`
+/// projection so that type-specific services (`article_from_row`,
+/// `claim_from_row`, …) can delegate the shared extraction here and only
+/// handle their own additional columns.
+pub(crate) struct NodeCore {
+    pub id: Uuid,
+    pub title: Option<String>,
+    pub content: Option<String>,
+    pub status: String,
+    pub confidence: f32,
+    pub epistemic_type: Option<String>,
+    pub domain_path: Vec<String>,
+    pub metadata: serde_json::Value,
+    pub version: i32,
+    pub pinned: bool,
+    pub usage_score: f32,
+    pub content_hash: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub modified_at: DateTime<Utc>,
+}
+
+/// Extract the common node fields from a Postgres row.
+///
+/// Callers should compose this with their own type-specific field extractions:
+///
+/// ```ignore
+/// fn article_from_row(row: &PgRow) -> ArticleResponse {
+///     let core = node_core_from_row(row);
+///     ArticleResponse {
+///         id: core.id,
+///         // … common fields …
+///         facet_function: row.get("facet_function"), // article-specific
+///     }
+/// }
+/// ```
+pub(crate) fn node_core_from_row(row: &PgRow) -> NodeCore {
+    NodeCore {
+        id: row.get("id"),
+        title: row.get("title"),
+        content: row.get("content"),
+        status: row.get("status"),
+        confidence: row.get::<Option<f64>, _>("confidence").unwrap_or(0.5) as f32,
+        epistemic_type: row.get("epistemic_type"),
+        domain_path: row
+            .get::<Option<Vec<String>>, _>("domain_path")
+            .unwrap_or_default(),
+        metadata: row.get::<serde_json::Value, _>("metadata"),
+        version: row.get::<Option<i32>, _>("version").unwrap_or(1),
+        pinned: row.get::<Option<bool>, _>("pinned").unwrap_or(false),
+        usage_score: row.get::<Option<f64>, _>("usage_score").unwrap_or(0.0) as f32,
+        content_hash: row.get("content_hash"),
+        created_at: row.get("created_at"),
+        modified_at: row.get("modified_at"),
+    }
+}

--- a/engine/tests/integration/test_kg_inference.rs
+++ b/engine/tests/integration/test_kg_inference.rs
@@ -97,8 +97,8 @@ async fn test_contradicts_symmetry_auto_inverse() {
 
     assert_eq!(
         inferred_by.as_deref(),
-        Some("contradicts_symmetry"),
-        "inverse edge metadata must carry inferred_by = contradicts_symmetry"
+        Some("symmetric_edge"),
+        "inverse edge metadata must carry inferred_by = symmetric_edge (generalized label, covalence#173 wave 5)"
     );
 
     fix.cleanup().await;


### PR DESCRIPTION
## Summary

Part of the [covalence#173](https://github.com/ourochronos/covalence/issues/173) surgical pre-claims refactor. Wave 5 implements three changes.

---

### Change 2.2 — Generalize symmetric-edge enforcement

**Files:** `engine/src/services/edge_service.rs`, `engine/src/models/mod.rs`

- Added `EdgeType::is_symmetric() -> bool` (returns `true` for `Contradicts` and `ContradictsClaim`)
- Extracted `EdgeService::ensure_symmetric_edge(from, to, edge_type, confidence, created_by, props)` as a private helper; replaces the old hardcoded `upsert_contradicts_edge` + raw-inverse-INSERT pair
- `create()` now branches on `edge_type.is_symmetric()` — symmetric types get the generalized helper, all others go through `graph.create_edge()`
- All `ON CONFLICT … DO NOTHING` idempotency semantics preserved; updated integration test asserting `inferred_by = "symmetric_edge"` (previously CONTRADICTS-specific `"contradicts_symmetry"`)

### Change 4.2 — Extract node-creation boilerplate

**Files:** `engine/src/services/article_service.rs`, new `engine/src/services/node_helpers.rs`, `engine/src/services/mod.rs`

New `pub(crate)` helpers in `node_helpers.rs`:
- `compute_content_hash(content: &str) -> String` — hex-encoded SHA-256
- `estimate_size_tokens(content: &str) -> i32` — word_count / 0.75 heuristic
- `async fn enqueue_embed_with_preamble(pool, node_id, title, node_type_str, domain_path)` — slow-path embed queue insert with contextual preamble

`article_service::create()` now delegates to these helpers; inline duplicates removed. Module registered as `pub(crate) mod node_helpers` in `services/mod.rs`.

### Change 4.3 — Extract `node_core_from_row`

**File:** `engine/src/services/node_helpers.rs` (+ `article_service.rs`)

- Added `pub(crate) struct NodeCore` (14 common node fields: id, title, content, status, confidence, epistemic_type, domain_path, metadata, version, pinned, usage_score, content_hash, created_at, modified_at)
- Added `pub(crate) fn node_core_from_row(row: &PgRow) -> NodeCore`
- `article_from_row` builds on `NodeCore`; article-specific fields (`contention_count`, `facet_function`, `facet_scope`, `stale`) remain inline

---

## Test Results

```
test result: ok. 240 passed; 0 failed; 0 ignored  (integration)
test result: ok. 97 passed; 0 failed; 0 ignored   (unit)
test result: ok. 15 passed; 0 failed; 0 ignored   (model tests)
... (all suites green)
Total: 386 passed; 0 failed
```

## Checklist
- [x] `cargo check` clean
- [x] `cargo fmt` applied before commit
- [x] `cargo test` — 386 passed, 0 failed
- [x] Only touches specified files (`edge_service.rs`, `models/mod.rs`, `article_service.rs`, `services/mod.rs`, new `node_helpers.rs`) + updated test
- [x] Claims layer, compilation pipeline untouched
