### PR TITLE
fix(edge-inference): add CONTENDS, fix excerpt window, remove RELATES_TO gate (#162)

### DIFF
--- a/engine/src/worker/infer_article_edges.rs
+++ b/engine/src/worker/infer_article_edges.rs
@@ -341,8 +341,7 @@ pub async fn handle_infer_article_edges(
         };
 
         // ── Tier 4: LLM directionality (selective) ────────────────────────────
-        if config.llm_enabled && combined_score >= config.llm_threshold && edge_type == "RELATES_TO"
-        {
+        if config.llm_enabled && combined_score >= config.llm_threshold {
             match llm_infer_directionality(pool, llm, subject_id, candidate.id).await {
                 Ok((llm_edge_type, llm_conf)) => {
                     edge_type = llm_edge_type;
@@ -695,7 +694,7 @@ async fn tier3_ann_candidates(
 /// between two articles.
 ///
 /// Returns `(edge_type, confidence)` where `edge_type` is one of
-/// `EXTENDS`, `CONFIRMS`, `CONTRADICTS`, or `RELATES_TO`.
+/// `EXTENDS`, `CONFIRMS`, `CONTRADICTS`, `CONTENDS`, or `RELATES_TO`.
 /// Confidence is clamped to `[0.5, 0.95]`.
 async fn llm_infer_directionality(
     pool: &PgPool,
@@ -705,9 +704,11 @@ async fn llm_infer_directionality(
 ) -> anyhow::Result<(String, f32)> {
     use sqlx::Row as _;
 
-    // Fetch short excerpts for both articles (first 500 chars each).
+    // Fetch excerpts for both articles.  Skip the first 150 chars (injected
+    // boilerplate on split articles per covalence#186) and take up to 2000
+    // chars of real content.
     let rows = sqlx::query(
-        "SELECT id, title, LEFT(content, 500) AS excerpt \
+        "SELECT id, title, SUBSTRING(content, 150, 2000) AS excerpt \
          FROM   covalence.nodes \
          WHERE  id = ANY($1)",
     )
@@ -740,13 +741,14 @@ async fn llm_infer_directionality(
          Article A:\nTitle: {subject_title}\nExcerpt: {subject_excerpt}\n\n\
          Article B:\nTitle: {candidate_title}\nExcerpt: {candidate_excerpt}\n\n\
          Return ONLY valid JSON (no markdown fences):\n\
-         {{\"relationship\": \"EXTENDS|CONFIRMS|CONTRADICTS|RELATES_TO\", \
+         {{\"relationship\": \"EXTENDS|CONFIRMS|CONTRADICTS|CONTENDS|RELATES_TO\", \
            \"confidence\": 0.0..1.0, \
            \"reasoning\": \"...\"}}\n\
          Where:\n\
          - EXTENDS: A elaborates/specializes B or vice-versa\n\
          - CONFIRMS: A and B corroborate each other\n\
-         - CONTRADICTS: A and B make conflicting claims\n\
+         - CONTRADICTS: A and B make incompatible, mutually exclusive claims\n\
+         - CONTENDS: one source contends (disputes without fully contradicting) a claim in the other\n\
          - RELATES_TO: topically related but no stronger relationship"
     );
 
@@ -777,7 +779,7 @@ async fn llm_infer_directionality(
         .unwrap_or("RELATES_TO");
 
     let edge_type = match rel {
-        "EXTENDS" | "CONFIRMS" | "CONTRADICTS" => rel.to_string(),
+        "EXTENDS" | "CONFIRMS" | "CONTRADICTS" | "CONTENDS" => rel.to_string(),
         _ => "RELATES_TO".to_string(),
     };
 


### PR DESCRIPTION
## Summary

Fixes three Tier 4 (article-to-article) adversarial edge inference bugs identified in the adversarial edge bias audit (covalence#162).  Together they caused a **100% false-negative rate** for CONTRADICTS/CONTENDS edges and a **~72% CONFIRMS false-positive rate**.

---

## Fixes

### Fix 1 — P0 · Add CONTENDS to Tier 4 LLM prompt enum (Cause A)

`llm_infer_directionality()` offered the LLM only `EXTENDS | CONFIRMS | CONTRADICTS | RELATES_TO`.  `CONTENDS` was absent, so any relationship that *disputes without fully contradicting* was silently collapsed into `RELATES_TO` — a 100% false-negative rate for CONTENDS edges.

**Change:** Added `CONTENDS` to the JSON enum in the prompt with the definition _"one source contends (disputes without fully contradicting) a claim in the other"_; also added it to the Rust match arm that maps LLM output to an `edge_type` string.

### Fix 2 — P1 · Change excerpt window from `LEFT(content, 500)` to `SUBSTRING(content, 150, 2000)` (Cause D)

The SQL in `llm_infer_directionality` fetched `LEFT(content, 500)`.  For split articles the first ~150 characters are injected boilerplate (tracked separately in covalence#186), so the LLM was classifying pairs based entirely on header noise rather than article content.

**Change:** `LEFT(content, 500)` → `SUBSTRING(content, 150, 2000)` — skips the boilerplate prefix and supplies up to 2 000 chars of substantive content to the LLM.

### Fix 3 — P1 · Remove `AND edge_type == "RELATES_TO"` gate (Cause B)

The Tier 4 guard required **both** `combined_score >= 0.85` **and** `edge_type == "RELATES_TO"`.  Candidates with `edge_type == "EXTENDS"` (assigned by Tier 2 structural signals) never entered the LLM path, so they could never be upgraded to `CONTRADICTS` or `CONTENDS`.

**Change:** Removed the `edge_type == "RELATES_TO"` conjunct.  The score gate (`combined_score >= config.llm_threshold`) is the correct and sufficient discriminator.

---

## Files changed

- `engine/src/worker/infer_article_edges.rs` — 10 insertions, 8 deletions

## Test results

`cargo fmt && cargo test` — **15/15 unit tests pass**, all doc-tests pass.

---

## Out of scope

The article_split boilerplate-injection root cause (covalence#186) is **intentionally not fixed here** — it has broader scope and is tracked separately.