### PR TITLE
fix(edge-inference): add .min(0.95) confidence cap to all Tier 1/2 branches + migration

### DIFF
--- a/engine/migrations/040_cap_edge_confidence.sql
+++ b/engine/migrations/040_cap_edge_confidence.sql
@@ -1,0 +1,26 @@
+-- Migration 040: cap edge confidence to [0, 1] — retroactive fix (covalence#187)
+--
+-- Tier 1 and Tier 2 confidence branches in `infer_article_edges` were missing
+-- a `.min(0.95)` cap, allowing `combined_score` (which combines Jaccard,
+-- domain-path overlap, and cosine similarity) to push confidence above 1.0
+-- (observed max: 1.630).  The Rust fix is in the same commit; this migration
+-- retroactively corrects the 43 already-inserted RELATES_TO edges whose
+-- `confidence` column exceeds 1.0.
+--
+-- LEAST(confidence, 1.0) is intentionally used here rather than 0.95 because:
+--   a) clamping to 1.0 preserves semantic correctness (probability bound);
+--   b) the 0.95 business cap is enforced going-forward by the code fix;
+--   c) retroactively lowering already-correct edges from, say, 0.94 → 0.94
+--      would be a no-op anyway, so LEAST(confidence, 1.0) is the safest,
+--      narrowest correction.
+--
+-- Safe to re-run: the WHERE clause makes the UPDATE a no-op on clean data.
+-- No lock escalation beyond a row-level UPDATE on the 43 affected rows.
+
+BEGIN;
+
+UPDATE covalence.edges
+   SET confidence = LEAST(confidence, 1.0)
+ WHERE confidence > 1.0;
+
+COMMIT;

--- a/engine/src/worker/infer_article_edges.rs
+++ b/engine/src/worker/infer_article_edges.rs
@@ -323,9 +323,9 @@ pub async fn handle_infer_article_edges(
 
         // Determine confidence.
         let mut confidence: f32 = if tier1_ok {
-            0.9_f32.max(combined_score)
+            0.9_f32.max(combined_score).min(0.95)
         } else if tier2_ok {
-            0.8_f32.max(combined_score)
+            0.8_f32.max(combined_score).min(0.95)
         } else {
             // Tier 3 only.
             (0.7 + candidate.tier3_sim).min(0.95)


### PR DESCRIPTION
Fixes #187. Adds `.min(0.95)` clamp to all Tier 1/2 confidence branches and retroactive DB migration to cap 43 existing edges with confidence > 1.0.