### PR TITLE
fix: cap slow_path_queue retry backoff at 1 hour (#193)

### DIFF
--- a/engine/src/worker/mod.rs
+++ b/engine/src/worker/mod.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 use llm::{LlmClient, StubLlmClient};
 
 /// Maximum number of attempts before a task is marked `failed`.
-const MAX_ATTEMPTS: i64 = 3;
+const MAX_ATTEMPTS: i64 = 5;
 
 /// How long we wait between poll cycles.
 const POLL_INTERVAL: Duration = Duration::from_secs(2);
@@ -327,19 +327,25 @@ async fn execute_and_finalize(pool: PgPool, llm: Arc<dyn LlmClient>, task: Queue
                     );
                 }
             } else {
+                // Compute capped exponential backoff: 60s, 120s, 240s, 480s, 960s (max 1 hour)
+                let backoff_secs = std::cmp::min(60 * (1i64 << (attempts - 1)), 3600);
+                let retry_after = chrono::Utc::now() + chrono::Duration::seconds(backoff_secs);
+
                 let result_json = json!({
                     "attempts":   attempts,
                     "last_error": error_msg,
                 });
                 if let Err(e) = sqlx::query(
                     r#"UPDATE covalence.slow_path_queue
-                       SET  status     = 'pending',
-                            started_at = null,
-                            result     = $1
+                       SET  status      = 'pending',
+                            started_at  = null,
+                            result      = $1,
+                            execute_after = $3
                        WHERE id = $2"#,
                 )
                 .bind(&result_json)
                 .bind(task.id)
+                .bind(retry_after)
                 .execute(&pool)
                 .await
                 {
@@ -348,12 +354,26 @@ async fn execute_and_finalize(pool: PgPool, llm: Arc<dyn LlmClient>, task: Queue
                         "worker: failed to requeue task: {e:#}"
                     );
                 } else {
-                    tracing::info!(
-                        task_id   = %task.id,
-                        task_type = %task.task_type,
-                        attempts,
-                        "worker: task requeued for retry"
-                    );
+                    // Log at WARN level if backoff exceeds 15 minutes
+                    if backoff_secs >= 900 {
+                        tracing::warn!(
+                            task_id      = %task.id,
+                            task_type    = %task.task_type,
+                            attempts,
+                            backoff_secs,
+                            retry_after  = %retry_after.to_rfc3339(),
+                            "worker: task requeued for retry with high backoff"
+                        );
+                    } else {
+                        tracing::info!(
+                            task_id      = %task.id,
+                            task_type    = %task.task_type,
+                            attempts,
+                            backoff_secs,
+                            retry_after  = %retry_after.to_rfc3339(),
+                            "worker: task requeued for retry with backoff"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Cap slow_path_queue retry backoff at 1 hour to prevent tasks from consolidation schedule staying stuck far in the future when they fail from transient errors.

## Changes
- ✅ Increase `MAX_ATTEMPTS` from 3 to 5 (lines changed: constant at line 48)
- ✅ Add capped exponential backoff computation: `min(60 * 2^(attempts-1), 3600)`
- ✅ Update requeue SQL to set `execute_after = $3` with computed `retry_after`
- ✅ Log `backoff_secs` and `retry_after` in tracing output
- ✅ Log at WARN level when backoff ≥ 15 minutes (900s)

## Backoff Sequence
- Attempt 1 → 2: 60s
- Attempt 2 → 3: 120s (2 min)
- Attempt 3 → 4: 240s (4 min)
- Attempt 4 → 5: 480s (8 min)
- Attempt 5 → fail: 960s (16 min, capped at 1h if formula exceeds)

All backoffs are capped at 3600s (1 hour) via `std::cmp::min`.

## Testing
- ✅ `cargo build --release` — succeeded
- ✅ `cargo test` — all 15 tests passed
- ✅ `cargo fmt` — applied

## Verification Points
- [x] The retry SQL now includes `execute_after = $3` parameter
- [x] `MAX_ATTEMPTS` is 5
- [x] Backoff is capped at 3600 seconds
- [x] Warning threshold set at 900s (15 min)
- [x] Cargo.lock is committed (no changes needed)

Fixes #193