### PR TITLE
feat: metadata filter + idempotency key (#196)

### DIFF
--- a/engine/migrations/043_source_metadata_gin_index.sql
+++ b/engine/migrations/043_source_metadata_gin_index.sql
@@ -1,0 +1,5 @@
+-- covalence#196: GIN index on source node metadata for JSONB containment queries.
+-- Enables efficient `metadata @> $filter::jsonb` filtering on source_list.
+CREATE INDEX IF NOT EXISTS idx_nodes_metadata_gin
+    ON covalence.nodes USING gin (metadata jsonb_path_ops)
+    WHERE node_type = 'source';

--- a/engine/src/services/session_service.rs
+++ b/engine/src/services/session_service.rs
@@ -312,6 +312,7 @@ impl SessionService {
             capture_method: Some("system".to_string()),
             facet_function: None,
             facet_scope: None,
+            idempotency_key: None,
         };
 
         let source = source_svc.ingest(ingest_req).await?;

--- a/engine/src/services/source_service.rs
+++ b/engine/src/services/source_service.rs
@@ -38,6 +38,11 @@ pub struct IngestRequest {
     /// Scope facet — abstraction level.
     /// e.g. `["practical"]`, `["theoretical", "operational"]` (covalence#92 Phase 1).
     pub facet_scope: Option<Vec<String>>,
+    /// Optional idempotency key (covalence#196). If a source with matching
+    /// `metadata.idempotency_key` exists in the same namespace, the existing
+    /// source is returned without creating a new one.  Checked BEFORE
+    /// fingerprint dedup.
+    pub idempotency_key: Option<String>,
 }
 
 /// Paginated list params.
@@ -48,6 +53,13 @@ pub struct ListParams {
     pub source_type: Option<String>,
     pub status: Option<String>,
     pub q: Option<String>,
+    /// Optional metadata filter — JSON object.  Sources whose `metadata`
+    /// column contains all specified key-value pairs are returned (JSONB `@>`
+    /// containment).  Requires the GIN index from migration 043.
+    ///
+    /// Passed as a JSON-encoded string in the query parameter:
+    /// `?metadata={"session_id":"abc123"}`
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Response envelope for a source.
@@ -119,6 +131,23 @@ impl SourceService {
         // 1. Compute fingerprint
         let fingerprint = hex::encode(Sha256::digest(req.content.as_bytes()));
 
+        // 1a. Idempotency key dedup (covalence#196) — checked BEFORE fingerprint dedup.
+        if let Some(ref key) = req.idempotency_key {
+            let existing = sqlx::query_scalar::<_, Uuid>(
+                "SELECT id FROM covalence.nodes \
+                 WHERE metadata->>'idempotency_key' = $1 \
+                 AND node_type = 'source' AND namespace = $2",
+            )
+            .bind(key)
+            .bind(&self.namespace)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some(id) = existing {
+                return self.get(id).await;
+            }
+        }
+
         // 2. Check for existing source with same fingerprint (idempotent, scoped to namespace)
         let existing = sqlx::query_scalar::<_, Uuid>(
             "SELECT id FROM covalence.nodes \
@@ -143,6 +172,10 @@ impl SourceService {
         // Persist capture_method into metadata so callers can read it back.
         if let Some(ref cm) = req.capture_method {
             metadata["capture_method"] = serde_json::json!(cm);
+        }
+        // Persist idempotency_key into metadata (covalence#196).
+        if let Some(ref key) = req.idempotency_key {
+            metadata["idempotency_key"] = serde_json::json!(key);
         }
         let source_type = req.source_type.unwrap_or_else(|| "document".into());
         let content_hash = hex::encode(Sha256::digest(req.content.as_bytes()));
@@ -259,6 +292,12 @@ impl SourceService {
             builder.push(" AND content_tsv @@ websearch_to_tsquery('english', ");
             builder.push_bind(q);
             builder.push(")");
+        }
+        // Metadata JSONB containment filter (covalence#196).
+        // Uses the GIN index from migration 043.
+        if let Some(ref meta_filter) = params.metadata {
+            builder.push(" AND metadata @> ");
+            builder.push_bind(meta_filter);
         }
         if let Some(cursor) = params.cursor {
             builder.push(" AND id > ");

--- a/engine/tests/integration/main.rs
+++ b/engine/tests/integration/main.rs
@@ -76,6 +76,7 @@ mod test_search_precision;
 mod test_search_temporal;
 mod test_security;
 mod test_session_ingestion;
+mod test_source_metadata_filter;
 mod test_source_quality;
 mod test_split;
 mod test_spreading_activation;

--- a/engine/tests/integration/test_content_hash.rs
+++ b/engine/tests/integration/test_content_hash.rs
@@ -44,6 +44,7 @@ async fn test_source_ingest_populates_content_hash() {
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
 
     let resp = svc.ingest(req).await.expect("ingest must succeed");
@@ -95,6 +96,7 @@ async fn test_source_get_exposes_content_hash() {
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
 
     let ingested = svc.ingest(req).await.expect("ingest must succeed");

--- a/engine/tests/integration/test_faceted_classification.rs
+++ b/engine/tests/integration/test_faceted_classification.rs
@@ -42,6 +42,7 @@ fn ingest_req(
         capture_method: None,
         facet_function,
         facet_scope,
+        idempotency_key: None,
     }
 }
 
@@ -299,6 +300,7 @@ async fn test_facet_boost_raises_aligned_score() {
             capture_method: None,
             facet_function: Some(vec!["retrieval".into()]),
             facet_scope: Some(vec!["practical".into()]),
+            idempotency_key: None,
         })
         .await
         .expect("ingest A should succeed");
@@ -317,6 +319,7 @@ async fn test_facet_boost_raises_aligned_score() {
             capture_method: None,
             facet_function: None, // no facets
             facet_scope: None,
+            idempotency_key: None,
         })
         .await
         .expect("ingest B should succeed");
@@ -546,6 +549,7 @@ async fn test_no_facet_request_no_boost_applied() {
             capture_method: None,
             facet_function: Some(vec!["retrieval".into()]),
             facet_scope: Some(vec!["practical".into()]),
+            idempotency_key: None,
         })
         .await
         .expect("ingest with facets");
@@ -563,6 +567,7 @@ async fn test_no_facet_request_no_boost_applied() {
             capture_method: None,
             facet_function: None,
             facet_scope: None,
+            idempotency_key: None,
         })
         .await
         .expect("ingest without facets");

--- a/engine/tests/integration/test_namespace.rs
+++ b/engine/tests/integration/test_namespace.rs
@@ -28,6 +28,7 @@ async fn insert_ns_source(fix: &mut TestFixture, ns: &str, title: &str, content:
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
     let svc = SourceService::new(fix.pool.clone()).with_namespace(ns.to_string());
     let resp = svc.ingest(req).await.expect("ingest should succeed");

--- a/engine/tests/integration/test_security.rs
+++ b/engine/tests/integration/test_security.rs
@@ -139,6 +139,7 @@ async fn test_ingest_rejects_oversized_content() {
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
 
     let result = svc.ingest(req).await;
@@ -173,6 +174,7 @@ async fn test_ingest_accepts_content_at_limit() {
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
 
     let result = svc.ingest(req).await;
@@ -202,6 +204,7 @@ async fn test_ingest_accepts_normal_content() {
         capture_method: None,
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     };
 
     let result = svc.ingest(req).await;

--- a/engine/tests/integration/test_source_metadata_filter.rs
+++ b/engine/tests/integration/test_source_metadata_filter.rs
@@ -1,0 +1,281 @@
+//! Integration tests for covalence#196 — metadata filter on source_list
+//! and idempotency key on source_ingest.
+
+use serial_test::serial;
+use serde_json::json;
+
+use covalence_engine::services::source_service::{IngestRequest, ListParams, SourceService};
+
+use super::helpers::TestFixture;
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_ingest(content: &str) -> IngestRequest {
+    IngestRequest {
+        content: content.to_string(),
+        source_type: Some("conversation".to_string()),
+        title: Some("test source".to_string()),
+        metadata: None,
+        session_id: None,
+        reliability: None,
+        capture_method: None,
+        facet_function: None,
+        facet_scope: None,
+        idempotency_key: None,
+    }
+}
+
+// ─── Change 1: Metadata filter on source_list ───────────────────────────────
+
+/// Listing with a metadata filter returns only sources whose metadata contains
+/// the specified key-value pairs (JSONB @> containment).
+#[tokio::test]
+#[serial]
+async fn test_metadata_filter_basic() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    // Ingest two sources with different session_id metadata.
+    let mut req1 = make_ingest("conversation about cats");
+    req1.metadata = Some(json!({"session_id": "sess-aaa", "chunk_index": 0}));
+    let src1 = svc.ingest(req1).await.expect("ingest 1");
+
+    let mut req2 = make_ingest("conversation about dogs");
+    req2.metadata = Some(json!({"session_id": "sess-bbb", "chunk_index": 0}));
+    let _src2 = svc.ingest(req2).await.expect("ingest 2");
+
+    let mut req3 = make_ingest("more about cats");
+    req3.metadata = Some(json!({"session_id": "sess-aaa", "chunk_index": 1}));
+    let src3 = svc.ingest(req3).await.expect("ingest 3");
+
+    // Filter by session_id = "sess-aaa"
+    let results = svc
+        .list(ListParams {
+            metadata: Some(json!({"session_id": "sess-aaa"})),
+            ..Default::default()
+        })
+        .await
+        .expect("list with metadata filter");
+
+    assert_eq!(results.len(), 2, "should find 2 sources for sess-aaa");
+    let ids: Vec<_> = results.iter().map(|r| r.id).collect();
+    assert!(ids.contains(&src1.id));
+    assert!(ids.contains(&src3.id));
+
+    // Filter by session_id + chunk_index (multi-key containment)
+    let results = svc
+        .list(ListParams {
+            metadata: Some(json!({"session_id": "sess-aaa", "chunk_index": 1})),
+            ..Default::default()
+        })
+        .await
+        .expect("list with multi-key metadata filter");
+
+    assert_eq!(results.len(), 1, "should find 1 source for sess-aaa chunk 1");
+    assert_eq!(results[0].id, src3.id);
+
+    fix.cleanup().await;
+}
+
+/// Listing with an empty metadata filter or None returns all sources (no filter applied).
+#[tokio::test]
+#[serial]
+async fn test_metadata_filter_none_returns_all() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    let mut req = make_ingest("source with meta");
+    req.metadata = Some(json!({"key": "val"}));
+    svc.ingest(req).await.expect("ingest");
+
+    svc.ingest(make_ingest("source without meta"))
+        .await
+        .expect("ingest 2");
+
+    // No metadata filter
+    let all = svc.list(ListParams::default()).await.expect("list all");
+    assert!(all.len() >= 2, "should return all sources without filter");
+
+    fix.cleanup().await;
+}
+
+// ─── Change 2: Idempotency key on source_ingest ────────────────────────────
+
+/// Ingesting with the same idempotency_key returns the existing source
+/// without creating a duplicate.
+#[tokio::test]
+#[serial]
+async fn test_idempotency_key_dedup() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    let mut req1 = make_ingest("session chunk content A");
+    req1.idempotency_key = Some("session:x:chunk:0".to_string());
+    let first = svc.ingest(req1).await.expect("first ingest");
+
+    // Second ingest with same key but DIFFERENT content — should return
+    // the existing source (idempotency key wins over different content).
+    let mut req2 = make_ingest("totally different content");
+    req2.idempotency_key = Some("session:x:chunk:0".to_string());
+    let second = svc.ingest(req2).await.expect("second ingest (dedup)");
+
+    assert_eq!(first.id, second.id, "should return same source on duplicate key");
+    assert_eq!(
+        second.content, "session chunk content A",
+        "content should be from the first ingest"
+    );
+
+    fix.cleanup().await;
+}
+
+/// The idempotency key is stored in metadata and can be queried back.
+#[tokio::test]
+#[serial]
+async fn test_idempotency_key_stored_in_metadata() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    let mut req = make_ingest("some content");
+    req.idempotency_key = Some("session:y:chunk:2".to_string());
+    let src = svc.ingest(req).await.expect("ingest");
+
+    assert_eq!(
+        src.metadata["idempotency_key"].as_str(),
+        Some("session:y:chunk:2"),
+        "idempotency_key should be in metadata"
+    );
+
+    fix.cleanup().await;
+}
+
+/// Idempotency key dedup is checked BEFORE fingerprint dedup.
+/// Two sources with the same content but different idempotency keys should
+/// still be deduped by fingerprint (second scenario: different key, same content).
+/// But if the first has an idempotency key and the second uses the SAME key,
+/// it's caught by the idempotency check before fingerprint is compared.
+#[tokio::test]
+#[serial]
+async fn test_idempotency_key_checked_before_fingerprint() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    // First ingest with idempotency key
+    let mut req1 = make_ingest("identical content");
+    req1.idempotency_key = Some("key-alpha".to_string());
+    let first = svc.ingest(req1).await.expect("first ingest");
+
+    // Second ingest with SAME idempotency key but same content too
+    let mut req2 = make_ingest("identical content");
+    req2.idempotency_key = Some("key-alpha".to_string());
+    let second = svc.ingest(req2).await.expect("second ingest");
+
+    assert_eq!(
+        first.id, second.id,
+        "same idempotency key should return existing source"
+    );
+
+    fix.cleanup().await;
+}
+
+/// Without an idempotency key, standard fingerprint dedup still works.
+#[tokio::test]
+#[serial]
+async fn test_fingerprint_dedup_still_works() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    let first = svc.ingest(make_ingest("fingerprint test content")).await.expect("first");
+    let second = svc.ingest(make_ingest("fingerprint test content")).await.expect("second");
+
+    assert_eq!(first.id, second.id, "fingerprint dedup should still work without idempotency key");
+
+    fix.cleanup().await;
+}
+
+/// Idempotency keys are namespace-scoped — same key in different namespaces
+/// should NOT dedup.
+#[tokio::test]
+#[serial]
+async fn test_idempotency_key_namespace_scoped() {
+    let fix = TestFixture::new().await;
+    let svc_a = SourceService::new(fix.pool.clone()).with_namespace("ns-alpha".to_string());
+    let svc_b = SourceService::new(fix.pool.clone()).with_namespace("ns-beta".to_string());
+
+    let mut req1 = make_ingest("ns-scoped content");
+    req1.idempotency_key = Some("shared-key".to_string());
+    let src_a = svc_a.ingest(req1).await.expect("ingest in ns-alpha");
+
+    let mut req2 = make_ingest("ns-scoped content in beta");
+    req2.idempotency_key = Some("shared-key".to_string());
+    let src_b = svc_b.ingest(req2).await.expect("ingest in ns-beta");
+
+    assert_ne!(
+        src_a.id, src_b.id,
+        "same idempotency key in different namespaces should create separate sources"
+    );
+
+    fix.cleanup().await;
+}
+
+// ─── Change 3: GIN index creation ──────────────────────────────────────────
+
+/// The GIN index on metadata for source nodes should exist after migrations.
+/// This test verifies the index was created by migration 043.
+#[tokio::test]
+#[serial]
+async fn test_gin_index_exists() {
+    let fix = TestFixture::new().await;
+
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(
+            SELECT 1 FROM pg_indexes
+            WHERE indexname = 'idx_nodes_metadata_gin'
+              AND tablename = 'nodes'
+              AND schemaname = 'covalence'
+        )",
+    )
+    .fetch_one(&fix.pool)
+    .await
+    .unwrap_or(false);
+
+    assert!(
+        exists,
+        "GIN index idx_nodes_metadata_gin should exist on covalence.nodes"
+    );
+
+    fix.cleanup().await;
+}
+
+/// Metadata containment queries should work efficiently (at minimum, they must
+/// work correctly — the index makes them fast).
+#[tokio::test]
+#[serial]
+async fn test_metadata_containment_query_works() {
+    let fix = TestFixture::new().await;
+    let svc = SourceService::new(fix.pool.clone());
+
+    // Ingest a source with nested metadata
+    let mut req = make_ingest("nested metadata test");
+    req.metadata = Some(json!({
+        "platform": "openclaw",
+        "session_id": "sess-nested",
+        "tags": ["important", "review"]
+    }));
+    let src = svc.ingest(req).await.expect("ingest");
+
+    // Query by a subset of metadata
+    let results = svc
+        .list(ListParams {
+            metadata: Some(json!({"platform": "openclaw"})),
+            ..Default::default()
+        })
+        .await
+        .expect("list by platform");
+
+    assert!(
+        results.iter().any(|r| r.id == src.id),
+        "should find source by platform metadata"
+    );
+
+    fix.cleanup().await;
+}

--- a/engine/tests/integration/test_source_metadata_filter.rs
+++ b/engine/tests/integration/test_source_metadata_filter.rs
@@ -1,8 +1,8 @@
 //! Integration tests for covalence#196 — metadata filter on source_list
 //! and idempotency key on source_ingest.
 
-use serial_test::serial;
 use serde_json::json;
+use serial_test::serial;
 
 use covalence_engine::services::source_service::{IngestRequest, ListParams, SourceService};
 
@@ -71,7 +71,11 @@ async fn test_metadata_filter_basic() {
         .await
         .expect("list with multi-key metadata filter");
 
-    assert_eq!(results.len(), 1, "should find 1 source for sess-aaa chunk 1");
+    assert_eq!(
+        results.len(),
+        1,
+        "should find 1 source for sess-aaa chunk 1"
+    );
     assert_eq!(results[0].id, src3.id);
 
     fix.cleanup().await;
@@ -119,7 +123,10 @@ async fn test_idempotency_key_dedup() {
     req2.idempotency_key = Some("session:x:chunk:0".to_string());
     let second = svc.ingest(req2).await.expect("second ingest (dedup)");
 
-    assert_eq!(first.id, second.id, "should return same source on duplicate key");
+    assert_eq!(
+        first.id, second.id,
+        "should return same source on duplicate key"
+    );
     assert_eq!(
         second.content, "session chunk content A",
         "content should be from the first ingest"
@@ -184,10 +191,19 @@ async fn test_fingerprint_dedup_still_works() {
     let fix = TestFixture::new().await;
     let svc = SourceService::new(fix.pool.clone());
 
-    let first = svc.ingest(make_ingest("fingerprint test content")).await.expect("first");
-    let second = svc.ingest(make_ingest("fingerprint test content")).await.expect("second");
+    let first = svc
+        .ingest(make_ingest("fingerprint test content"))
+        .await
+        .expect("first");
+    let second = svc
+        .ingest(make_ingest("fingerprint test content"))
+        .await
+        .expect("second");
 
-    assert_eq!(first.id, second.id, "fingerprint dedup should still work without idempotency key");
+    assert_eq!(
+        first.id, second.id,
+        "fingerprint dedup should still work without idempotency key"
+    );
 
     fix.cleanup().await;
 }

--- a/engine/tests/integration/test_source_quality.rs
+++ b/engine/tests/integration/test_source_quality.rs
@@ -28,6 +28,7 @@ fn make_observation_request(capture_method: Option<&str>) -> IngestRequest {
         capture_method: capture_method.map(str::to_owned),
         facet_function: None,
         facet_scope: None,
+        idempotency_key: None,
     }
 }
 
@@ -125,6 +126,7 @@ async fn test_capture_method_stored_in_metadata() {
             capture_method: Some("manual".to_string()),
             facet_function: None,
             facet_scope: None,
+            idempotency_key: None,
         })
         .await
         .expect("ingest should succeed");

--- a/engine/tests/test_db_schema.sql
+++ b/engine/tests/test_db_schema.sql
@@ -318,6 +318,11 @@ CREATE INDEX IF NOT EXISTS node_sections_hnsw_idx
 CREATE INDEX IF NOT EXISTS nodes_metadata_gin_idx
     ON covalence.nodes USING gin (metadata);
 
+-- covalence#196: partial GIN index with jsonb_path_ops for source metadata containment queries.
+CREATE INDEX IF NOT EXISTS idx_nodes_metadata_gin
+    ON covalence.nodes USING gin (metadata jsonb_path_ops)
+    WHERE node_type = 'source';
+
 CREATE INDEX IF NOT EXISTS nodes_content_tsv_gin_idx
     ON covalence.nodes USING gin (content_tsv);
 


### PR DESCRIPTION
Implements covalence#196. Additive API primitives for session ingestion. See specs/session-ingestion-primitives.md

## Changes

### Change 1: Metadata filter on `source_list`
- Added optional `metadata` JSONB filter parameter to `ListParams`
- Implementation: JSONB containment query (`metadata @> $filter::jsonb`)
- Migration 043: GIN index with `jsonb_path_ops` on source node metadata

### Change 2: Idempotency key on `source_ingest`
- Added optional `idempotency_key` field to `IngestRequest`
- Checked BEFORE fingerprint dedup — if matching key exists in namespace, returns existing source
- Key is automatically stored in `metadata.idempotency_key`

### Tests
- 9 new integration tests covering both features
- All 250 integration tests pass
- Tier 2: additive only, no breaking changes