### PR TITLE
feat(engine): Route LLM calls through Covalence plugin inference proxy (#150)

### DIFF
--- a/docs/covalence-150-plist-update.md
+++ b/docs/covalence-150-plist-update.md
@@ -1,0 +1,62 @@
+# Covalence #150: LaunchAgent plist update
+
+## Change Required
+
+Update `~/Library/LaunchAgents/ai.ourochronos.covalence-engine.plist` to route LLM calls through the Covalence plugin inference proxy.
+
+## Current Configuration
+
+```xml
+<key>OPENAI_BASE_URL</key>
+<string>https://api.openai.com/v1</string>
+```
+
+## New Configuration
+
+```xml
+<key>OPENAI_BASE_URL</key>
+<string>http://localhost:18789/covalence/v1</string>
+```
+
+## Why This Change
+
+The Covalence engine currently hits OpenAI directly for embeddings and chat completions, bypassing subscription-based providers. The plugin already has a working OpenAI-compatible proxy at `localhost:18789/covalence/v1`. By updating `OPENAI_BASE_URL`, all LLM calls will be routed through the proxy, enabling:
+
+1. Use of subscription-based models (GitHub Copilot, etc.)
+2. Centralized credential management through the OpenClaw gateway
+3. Request logging and monitoring via the plugin proxy
+
+## Environment Variables in Plist
+
+The plist already sets:
+- `COVALENCE_CHAT_MODEL=gpt-4.1-mini` (now wired up in main.rs)
+- `COVALENCE_EMBED_MODEL=text-embedding-3-small` (already wired up)
+- `OPENAI_API_KEY` (will be passed to proxy for auth)
+
+## Apply the Change
+
+```bash
+# 1. Stop the service
+launchctl unload ~/Library/LaunchAgents/ai.ourochronos.covalence-engine.plist
+
+# 2. Edit the plist
+# Change OPENAI_BASE_URL to http://localhost:18789/covalence/v1
+
+# 3. Reload the service
+launchctl load ~/Library/LaunchAgents/ai.ourochronos.covalence-engine.plist
+```
+
+## Verification
+
+After reloading, check logs:
+```bash
+tail -f ~/projects/covalence/engine/logs/engine-stderr.log
+```
+
+Look for successful embedding/chat requests going through the proxy endpoint.
+
+## Notes
+
+- This plist file is outside the repository (in `~/Library/LaunchAgents/`)
+- The change is documented here for manual application
+- After the plist change, the engine will route through the plugin proxy automatically

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -75,6 +75,9 @@ async fn main() -> anyhow::Result<()> {
             if let Ok(model) = std::env::var("COVALENCE_EMBED_MODEL") {
                 client = client.with_embed_model(model);
             }
+            if let Ok(model) = std::env::var("COVALENCE_CHAT_MODEL") {
+                client = client.with_chat_model(model);
+            }
             tracing::info!("search using OpenAI embeddings for query auto-embed");
             std::sync::Arc::new(client)
         }


### PR DESCRIPTION
## Summary

Implements covalence#150 by routing engine LLM calls through the Covalence plugin inference proxy.

## Changes

1. **engine/src/main.rs**: Wire up COVALENCE_CHAT_MODEL env var
   - Add logic to read COVALENCE_CHAT_MODEL and pass to OpenAiClient::with_chat_model()
   - Follows same pattern as existing COVALENCE_EMBED_MODEL support

2. **docs/covalence-150-plist-update.md**: Document LaunchAgent plist update
   - Instructions for updating OPENAI_BASE_URL to http://localhost:18789/covalence/v1
   - The plist file is outside the repo, so documented for manual application

## Configuration

The plugin config (~/.openclaw/openclaw.json) already has the correct setting:
```json
"inferenceModel": "github-copilot/gpt-4.1-mini"
```

The LaunchAgent plist already sets:
- COVALENCE_CHAT_MODEL=gpt-4.1-mini (now wired up ✅)
- COVALENCE_EMBED_MODEL=text-embedding-3-small (already wired up ✅)

After merging and applying the plist update, all engine LLM calls will route through the plugin proxy, enabling use of subscription-based models via GitHub Copilot.

## Testing

- ✅ cargo build succeeds
- Manual testing required after plist update

## Related

Fixes #150