### PR TITLE
fix(migration): add 'claim' to nodes_node_type_check (closes #202 partial)

### DIFF
--- a/engine/migrations/044_add_claim_node_type.sql
+++ b/engine/migrations/044_add_claim_node_type.sql
@@ -1,0 +1,30 @@
+-- Migration 044: add 'claim' to nodes_node_type_check constraint (covalence#202 partial)
+--
+-- Migration 042 (claims layer, PR #191, covalence#169) added support for
+-- node_type='claim' but did not update the CHECK constraint on covalence.nodes.
+-- This caused ALL claim extraction tasks (~1,489) to fail with:
+--
+--   new row for relation "nodes" violates check constraint "nodes_node_type_check"
+--
+-- This migration drops the old constraint and recreates it with 'claim' included.
+--
+-- This fix was manually applied to production on 2026-03-05 to unblock claim
+-- extraction. This migration ensures the schema change is captured in version
+-- control and can be replayed on test/dev databases.
+--
+-- Safe to re-run: uses IF EXISTS for the DROP, and the constraint definition
+-- is idempotent. If the constraint already includes 'claim', this migration
+-- completes successfully without error.
+
+BEGIN;
+
+-- Drop the old constraint (safe if already dropped or doesn't exist)
+ALTER TABLE covalence.nodes 
+    DROP CONSTRAINT IF EXISTS nodes_node_type_check;
+
+-- Add the new constraint with 'claim' included
+ALTER TABLE covalence.nodes 
+    ADD CONSTRAINT nodes_node_type_check 
+    CHECK (node_type = ANY (ARRAY['article', 'source', 'entity', 'claim']));
+
+COMMIT;


### PR DESCRIPTION
## Problem

Migration 042 (claims layer, PR #191, covalence#169) added support for `node_type='claim'` but **forgot to update the CHECK constraint** on `covalence.nodes`. This caused ALL claim extraction tasks (~1,489) to fail with:

```
new row for relation "nodes" violates check constraint "nodes_node_type_check"
```

## Solution

This migration:
1. Drops the old `nodes_node_type_check` constraint
2. Recreates it with `'claim'` included: `['article', 'source', 'entity', 'claim']`
3. Is idempotent and safe to re-run

## Context

The fix was **manually applied to production** on 2026-03-05 to unblock claim extraction. This migration ensures the schema change is:
- Captured in version control
- Reproducible on test/dev databases
- Documented for future schema reviews

## Testing

- [x] Migration file follows established conventions (matches style of migrations 040-043)
- [x] Uses `IF EXISTS` for idempotency
- [x] Includes detailed comment explaining the gap in migration 042
- [x] No other files modified (focused, surgical fix)

## Related

- Closes #202 (partial - schema fix only)
- Fixes gap introduced in PR #191 (migration 042)
- Related to covalence#169 (claims layer implementation)

## Review Notes

This is a **critical bug fix** that unblocks claim extraction. The constraint definition exactly matches what was applied to production manually.